### PR TITLE
Implement alternative union encodings

### DIFF
--- a/src/FSharp.SystemTextJson/All.fs
+++ b/src/FSharp.SystemTextJson/All.fs
@@ -2,28 +2,37 @@
 
 open System
 open FSharp.Reflection
+open System.Runtime.InteropServices
 
-type JsonFSharpConverter() =
+type JsonFSharpConverter
+    (
+        [<Optional; DefaultParameterValue(JsonUnionEncoding.Default)>]
+        unionEncoding: JsonUnionEncoding
+    ) =
     inherit JsonConverterFactory()
 
     override this.CanConvert(typeToConvert) =
         JsonRecordConverter.CanConvert(typeToConvert) ||
         JsonUnionConverter.CanConvert(typeToConvert)
 
-    static member internal CreateConverter(typeToConvert) =
+    static member internal CreateConverter(typeToConvert, unionEncoding) =
         if JsonRecordConverter.CanConvert(typeToConvert) then
             JsonRecordConverter.CreateConverter(typeToConvert)
         elif JsonUnionConverter.CanConvert(typeToConvert) then
-            JsonUnionConverter.CreateConverter(typeToConvert)
+            JsonUnionConverter.CreateConverter(typeToConvert, unionEncoding)
         else
             invalidOp ("Not an F# record or union type: " + typeToConvert.FullName)
 
     override this.CreateConverter(typeToConvert) =
-        JsonFSharpConverter.CreateConverter(typeToConvert)
+        JsonFSharpConverter.CreateConverter(typeToConvert, unionEncoding)
 
 [<AttributeUsage(AttributeTargets.Class ||| AttributeTargets.Struct)>]
-type JsonFSharpConverterAttribute() =
+type JsonFSharpConverterAttribute
+    (
+        [<Optional; DefaultParameterValue(JsonUnionEncoding.Default)>]
+        unionEncoding: JsonUnionEncoding
+    ) =
     inherit JsonConverterAttribute()
 
     override __.CreateConverter(typeToConvert) =
-        JsonFSharpConverter.CreateConverter(typeToConvert)
+        JsonFSharpConverter.CreateConverter(typeToConvert, unionEncoding)

--- a/src/FSharp.SystemTextJson/Union.fs
+++ b/src/FSharp.SystemTextJson/Union.fs
@@ -4,6 +4,46 @@ open System
 open System.Reflection
 open System.Text.Json
 open FSharp.Reflection
+open System.Runtime.InteropServices
+
+type JsonUnionEncoding =
+
+    //// General base format
+
+    /// Encode unions as a 2-valued object:
+    /// "Case" contains the union tag, and "Fields" contains the union fields.
+    /// If the case doesn't have fields, "Fields": [] is omitted.
+    | AdjacentTag       = 0x00_01
+
+    /// Encode unions as a 1-valued object:
+    /// The field name is the union tag, and the value is the union fields.
+    | ExternalTag       = 0x00_02
+
+    /// Encode unions as a (n+1)-valued object or array (depending on NamedFields):
+    /// the first value (named "Case" if NamedFields is set) is the union tag, the rest are the union fields.
+    | InternalTag       = 0x00_04
+
+    /// Encode unions as a n-valued object:
+    /// the union tag is not encoded, only the union fields are.
+    /// Deserialization is only possible if the fields of all cases have different names.
+    | Untagged          = 0x01_08
+
+
+    //// Additional options
+
+    /// If unset, union fields are encoded as an array.
+    /// If set, union fields are encoded as an object using their field names.
+    | NamedFields       = 0x01_00
+
+    /// If set, union cases that don't have fields are encoded as a bare string.
+    | BareFieldlessTags = 0x02_00
+
+
+    //// Specific formats
+
+    | Default           = 0x00_01
+    | NewtonsoftLike    = 0x00_01
+    | ThothLike         = 0x00_04
 
 type private Case =
     {
@@ -13,11 +53,13 @@ type private Case =
         Dector: obj -> obj[]
     }
 
-type JsonUnionConverter<'T>() =
+type JsonUnionConverter<'T>(encoding: JsonUnionEncoding) =
     inherit JsonConverter<'T>()
 
+    static let ty = typeof<'T>
+
     static let cases =
-        FSharpType.GetUnionCases(typeof<'T>, true)
+        FSharpType.GetUnionCases(ty, true)
         |> Array.map (fun uci ->
             {
                 Info = uci
@@ -26,10 +68,10 @@ type JsonUnionConverter<'T>() =
                 Dector = FSharpValue.PreComputeUnionReader(uci, true)
             })
 
-    static let tagReader = FSharpValue.PreComputeUnionTagReader(typeof<'T>, true)
+    static let tagReader = FSharpValue.PreComputeUnionTagReader(ty, true)
 
     static let usesNull =
-        typeof<'T>.GetCustomAttributes(typeof<CompilationRepresentationAttribute>, false)
+        ty.GetCustomAttributes(typeof<CompilationRepresentationAttribute>, false)
         |> Array.exists (fun x ->
             let x = (x :?> CompilationRepresentationAttribute)
             x.Flags.HasFlag(CompilationRepresentationFlags.UseNullAsTrueValue))
@@ -47,7 +89,7 @@ type JsonUnionConverter<'T>() =
 
     static let fail expected (reader: byref<Utf8JsonReader>) =
         sprintf "Failed to parse union type %s: expected %s, found %A"
-            typeof<'T>.FullName expected reader.TokenType
+            ty.FullName expected reader.TokenType
         |> JsonException
         |> raise
 
@@ -59,62 +101,120 @@ type JsonUnionConverter<'T>() =
         if not (reader.Read()) || reader.TokenType <> JsonTokenType.PropertyName || not (reader.ValueTextEquals expectedPropertyName) then
             fail ("\"" + expectedPropertyName + "\"") &reader
 
-    override __.Read(reader, typeToConvert, options) =
+    static let getCaseTag (reader: byref<Utf8JsonReader>) =
+        match caseIndex &reader with
+        | ValueNone ->
+            raise (JsonException("Unknow case for union type " + ty.FullName + ": " + reader.GetString()))
+        | ValueSome case ->
+            case
+
+    static let readFieldsAsArray (reader: byref<Utf8JsonReader>) (case: Case) (options: JsonSerializerOptions) =
+        let fieldCount = case.Fields.Length
+        let fields = Array.zeroCreate fieldCount
+        readExpecting JsonTokenType.StartArray "array" &reader
+        for i in 0..fieldCount-1 do
+            reader.Read() |> ignore
+            fields.[i] <- JsonSerializer.Deserialize(&reader, case.Fields.[i].PropertyType, options)
+        readExpecting JsonTokenType.EndArray "end of array" &reader
+        case.Ctor fields :?> 'T
+
+    static let readAdjacentTag (reader: byref<Utf8JsonReader>) (options: JsonSerializerOptions) =
         match reader.TokenType with
-        | JsonTokenType.Null when usesNull ->
-            (null : obj) :?> 'T
         | JsonTokenType.StartObject ->
             readExpectingPropertyNamed "Case" &reader
             readExpecting JsonTokenType.String "case name" &reader
-            match caseIndex &reader with
-            | ValueNone ->
-                raise (JsonException("Unknow case for union type " + typeToConvert.FullName + ": " + reader.GetString()))
-            | ValueSome case ->
-                let fieldCount = case.Fields.Length
-                let fields = Array.zeroCreate fieldCount
+            let case = getCaseTag &reader
+            let res =
                 if case.Fields.Length > 0 then
                     readExpectingPropertyNamed "Fields" &reader
-                    readExpecting JsonTokenType.StartArray "array" &reader
-                    for i in 0..fieldCount-1 do
-                        reader.Read() |> ignore
-                        fields.[i] <- JsonSerializer.Deserialize(&reader, case.Fields.[i].PropertyType, options)
-                    readExpecting JsonTokenType.EndArray "end of array" &reader
-                readExpecting JsonTokenType.EndObject "end of object" &reader
-                case.Ctor fields :?> 'T
+                    readFieldsAsArray &reader case options
+                else
+                    case.Ctor [||] :?> 'T
+            readExpecting JsonTokenType.EndObject "end of object" &reader
+            res
         | _ ->
             fail "JSON object" &reader
 
-    override this.Write(writer, value, options) =
-        let value = box value
-        if isNull value then writer.WriteNullValue() else
+    static let readExternalTag (reader: byref<Utf8JsonReader>) (options: JsonSerializerOptions) =
+        match reader.TokenType with
+        | JsonTokenType.StartObject ->
+            readExpecting JsonTokenType.PropertyName "case name" &reader
+            let case = getCaseTag(&reader)
+            let res = readFieldsAsArray &reader case options
+            readExpecting JsonTokenType.EndObject "end of object" &reader
+            res
+        | _ ->
+            fail "JSON object" &reader
 
+    static let writeFieldsAsArray (writer: Utf8JsonWriter) (case: Case) (value: obj) (options: JsonSerializerOptions) =
+        writer.WriteStartArray()
+        for field in case.Dector value do
+            JsonSerializer.Serialize(writer, field, options)
+        writer.WriteEndArray()
+
+    static let writeAdjacentTag (writer: Utf8JsonWriter) (value: obj) (options: JsonSerializerOptions) =
         let tag = tagReader value
         let case = cases.[tag]
         writer.WriteStartObject()
         writer.WriteString("Case", case.Info.Name)
         if case.Fields.Length > 0 then
             writer.WritePropertyName("Fields")
-            writer.WriteStartArray()
-            for field in case.Dector value do
-                JsonSerializer.Serialize(writer, field, options)
-            writer.WriteEndArray()
+            writeFieldsAsArray writer case value options
         writer.WriteEndObject()
 
-type JsonUnionConverter() =
+    static let writeExternalTag (writer: Utf8JsonWriter) (value: obj) (options: JsonSerializerOptions) =
+        let tag = tagReader value
+        let case = cases.[tag]
+        writer.WriteStartObject()
+        writer.WritePropertyName(case.Info.Name)
+        writeFieldsAsArray writer case value options
+        writer.WriteEndObject()
+
+    override __.Read(reader, _typeToConvert, options) =
+        match reader.TokenType with
+        | JsonTokenType.Null when usesNull ->
+            (null : obj) :?> 'T
+        | _ ->
+            if encoding.HasFlag(JsonUnionEncoding.AdjacentTag) then
+                readAdjacentTag &reader options
+            elif encoding.HasFlag(JsonUnionEncoding.ExternalTag) then
+                readExternalTag &reader options
+            else
+                raise (JsonException("Unsupported union encoding: " + string encoding))
+
+    override __.Write(writer, value, options) =
+        let value = box value
+        if isNull value then writer.WriteNullValue() else
+
+        if encoding.HasFlag(JsonUnionEncoding.AdjacentTag) then
+            writeAdjacentTag writer value options
+        elif encoding.HasFlag(JsonUnionEncoding.ExternalTag) then
+            writeExternalTag writer value options
+        else
+            raise (JsonException("Unsupported union encoding: " + string encoding))
+
+type JsonUnionConverter
+    (
+        [<Optional; DefaultParameterValue(JsonUnionEncoding.Default)>]
+        encoding: JsonUnionEncoding
+    ) =
     inherit JsonConverterFactory()
+
+    static let jsonUnionConverterTy = typedefof<JsonUnionConverter<_>>
+    static let jsonUnionEncodingTy = typeof<JsonUnionEncoding>
 
     static member internal CanConvert(typeToConvert) =
         TypeCache.isUnion typeToConvert
 
-    static member internal CreateConverter(typeToConvert) =
-        typedefof<JsonUnionConverter<_>>
+    static member internal CreateConverter(typeToConvert, encoding: JsonUnionEncoding) =
+        jsonUnionConverterTy
             .MakeGenericType([|typeToConvert|])
-            .GetConstructor([||])
-            .Invoke([||])
+            .GetConstructor([|jsonUnionEncodingTy|])
+            .Invoke([|encoding|])
         :?> JsonConverter
 
     override this.CanConvert(typeToConvert) =
         JsonUnionConverter.CanConvert(typeToConvert)
 
     override this.CreateConverter(typeToConvert) =
-        JsonUnionConverter.CreateConverter(typeToConvert)
+        JsonUnionConverter.CreateConverter(typeToConvert, encoding)

--- a/src/FSharp.SystemTextJson/Union.fs
+++ b/src/FSharp.SystemTextJson/Union.fs
@@ -43,7 +43,7 @@ type JsonUnionEncoding =
 
     | Default           = 0x00_01
     | NewtonsoftLike    = 0x00_01
-    | ThothLike         = 0x00_04
+    | ThothLike         = 0x02_04
 
 type private Case =
     {

--- a/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
@@ -149,6 +149,19 @@ module NonStruct =
         Assert.Equal("""{"Case":"Bb","Item":32}""", JsonSerializer.Serialize(Bb 32, internalTagNamedFieldsOptions))
         Assert.Equal("""{"Case":"Bc","x":"test","Item2":true}""", JsonSerializer.Serialize(Bc("test", true), internalTagNamedFieldsOptions))
 
+    let bareFieldlessTagsOptions = JsonSerializerOptions()
+    bareFieldlessTagsOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.BareFieldlessTags))
+
+    type S = { b: B }
+
+    [<Fact>]
+    let ``deserialize BareFieldlessTags`` () =
+        Assert.Equal({b=Ba}, JsonSerializer.Deserialize("""{"b":"Ba"}""", bareFieldlessTagsOptions))
+
+    [<Fact>]
+    let ``serialize BareFieldlessTags`` () =
+        Assert.Equal("""{"b":"Ba"}""", JsonSerializer.Serialize({b=Ba}, bareFieldlessTagsOptions))
+
 module Struct =
 
     [<Struct; JsonFSharpConverter>]
@@ -279,3 +292,17 @@ module Struct =
         Assert.Equal("""{"Case":"Ba"}""", JsonSerializer.Serialize(Ba, internalTagNamedFieldsOptions))
         Assert.Equal("""{"Case":"Bb","Item":32}""", JsonSerializer.Serialize(Bb 32, internalTagNamedFieldsOptions))
         Assert.Equal("""{"Case":"Bc","x":"test","Item2":true}""", JsonSerializer.Serialize(Bc("test", true), internalTagNamedFieldsOptions))
+
+    let bareFieldlessTagsOptions = JsonSerializerOptions()
+    bareFieldlessTagsOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.BareFieldlessTags))
+
+    [<Struct>]
+    type S = { b: B }
+
+    [<Fact>]
+    let ``deserialize BareFieldlessTags`` () =
+        Assert.Equal({b=Ba}, JsonSerializer.Deserialize("""{"b":"Ba"}""", bareFieldlessTagsOptions))
+
+    [<Fact>]
+    let ``serialize BareFieldlessTags`` () =
+        Assert.Equal("""{"b":"Ba"}""", JsonSerializer.Serialize({b=Ba}, bareFieldlessTagsOptions))

--- a/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
@@ -27,7 +27,7 @@ module NonStruct =
     type B =
         | Ba
         | Bb of int
-        | Bc of string * bool
+        | Bc of x: string * bool
 
     let options = JsonSerializerOptions()
     options.Converters.Add(JsonFSharpConverter())
@@ -89,6 +89,51 @@ module NonStruct =
         Assert.Equal("""["Bb",32]""", JsonSerializer.Serialize(Bb 32, internalTagOptions))
         Assert.Equal("""["Bc","test",true]""", JsonSerializer.Serialize(Bc("test", true), internalTagOptions))
 
+    let adjacentTagNamedFieldsOptions = JsonSerializerOptions()
+    adjacentTagNamedFieldsOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.AdjacentTag ||| JsonUnionEncoding.NamedFields))
+
+    [<Fact>]
+    let ``deserialize AdjacentTag NamedFields`` () =
+        Assert.Equal(Ba, JsonSerializer.Deserialize("""{"Case":"Ba"}""", adjacentTagNamedFieldsOptions))
+        Assert.Equal(Bb 32, JsonSerializer.Deserialize("""{"Case":"Bb","Fields":{"Item":32}}""", adjacentTagNamedFieldsOptions))
+        Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"Case":"Bc","Fields":{"x":"test","Item2":true}}""", adjacentTagNamedFieldsOptions))
+
+    [<Fact>]
+    let ``serialize AdjacentTag NamedFields`` () =
+        Assert.Equal("""{"Case":"Ba"}""", JsonSerializer.Serialize(Ba, adjacentTagNamedFieldsOptions))
+        Assert.Equal("""{"Case":"Bb","Fields":{"Item":32}}""", JsonSerializer.Serialize(Bb 32, adjacentTagNamedFieldsOptions))
+        Assert.Equal("""{"Case":"Bc","Fields":{"x":"test","Item2":true}}""", JsonSerializer.Serialize(Bc("test", true), adjacentTagNamedFieldsOptions))
+
+    let externalTagNamedFieldsOptions = JsonSerializerOptions()
+    externalTagNamedFieldsOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.ExternalTag ||| JsonUnionEncoding.NamedFields))
+
+    [<Fact>]
+    let ``deserialize ExternalTag NamedFields`` () =
+        Assert.Equal(Ba, JsonSerializer.Deserialize("""{"Ba":{}}""", externalTagNamedFieldsOptions))
+        Assert.Equal(Bb 32, JsonSerializer.Deserialize("""{"Bb":{"Item":32}}""", externalTagNamedFieldsOptions))
+        Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"Bc":{"x":"test","Item2":true}}""", externalTagNamedFieldsOptions))
+
+    [<Fact>]
+    let ``serialize ExternalTag NamedFields`` () =
+        Assert.Equal("""{"Ba":{}}""", JsonSerializer.Serialize(Ba, externalTagNamedFieldsOptions))
+        Assert.Equal("""{"Bb":{"Item":32}}""", JsonSerializer.Serialize(Bb 32, externalTagNamedFieldsOptions))
+        Assert.Equal("""{"Bc":{"x":"test","Item2":true}}""", JsonSerializer.Serialize(Bc("test", true), externalTagNamedFieldsOptions))
+
+    let internalTagNamedFieldsOptions = JsonSerializerOptions()
+    internalTagNamedFieldsOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.InternalTag ||| JsonUnionEncoding.NamedFields))
+
+    [<Fact>]
+    let ``deserialize InternalTag NamedFields`` () =
+        Assert.Equal(Ba, JsonSerializer.Deserialize("""{"Case":"Ba"}""", internalTagNamedFieldsOptions))
+        Assert.Equal(Bb 32, JsonSerializer.Deserialize("""{"Case":"Bb","Item":32}""", internalTagNamedFieldsOptions))
+        Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"Case":"Bc","x":"test","Item2":true}""", internalTagNamedFieldsOptions))
+
+    [<Fact>]
+    let ``serialize InternalTag NamedFields`` () =
+        Assert.Equal("""{"Case":"Ba"}""", JsonSerializer.Serialize(Ba, internalTagNamedFieldsOptions))
+        Assert.Equal("""{"Case":"Bb","Item":32}""", JsonSerializer.Serialize(Bb 32, internalTagNamedFieldsOptions))
+        Assert.Equal("""{"Case":"Bc","x":"test","Item2":true}""", JsonSerializer.Serialize(Bc("test", true), internalTagNamedFieldsOptions))
+
 module Struct =
 
     [<Struct; JsonFSharpConverter>]
@@ -113,7 +158,7 @@ module Struct =
     type B =
         | Ba
         | Bb of int
-        | Bc of string * bool
+        | Bc of x: string * bool
 
     let options = JsonSerializerOptions()
     options.Converters.Add(JsonFSharpConverter())
@@ -159,3 +204,33 @@ module Struct =
         Assert.Equal("""["Ba"]""", JsonSerializer.Serialize(Ba, internalTagOptions))
         Assert.Equal("""["Bb",32]""", JsonSerializer.Serialize(Bb 32, internalTagOptions))
         Assert.Equal("""["Bc","test",true]""", JsonSerializer.Serialize(Bc("test", true), internalTagOptions))
+
+    let externalTagNamedFieldsOptions = JsonSerializerOptions()
+    externalTagNamedFieldsOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.ExternalTag ||| JsonUnionEncoding.NamedFields))
+
+    [<Fact>]
+    let ``deserialize ExternalTag NamedFields`` () =
+        Assert.Equal(Ba, JsonSerializer.Deserialize("""{"Ba":{}}""", externalTagNamedFieldsOptions))
+        Assert.Equal(Bb 32, JsonSerializer.Deserialize("""{"Bb":{"Item":32}}""", externalTagNamedFieldsOptions))
+        Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"Bc":{"x":"test","Item2":true}}""", externalTagNamedFieldsOptions))
+
+    [<Fact>]
+    let ``serialize ExternalTag NamedFields`` () =
+        Assert.Equal("""{"Ba":{}}""", JsonSerializer.Serialize(Ba, externalTagNamedFieldsOptions))
+        Assert.Equal("""{"Bb":{"Item":32}}""", JsonSerializer.Serialize(Bb 32, externalTagNamedFieldsOptions))
+        Assert.Equal("""{"Bc":{"x":"test","Item2":true}}""", JsonSerializer.Serialize(Bc("test", true), externalTagNamedFieldsOptions))
+
+    let internalTagNamedFieldsOptions = JsonSerializerOptions()
+    internalTagNamedFieldsOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.InternalTag ||| JsonUnionEncoding.NamedFields))
+
+    [<Fact>]
+    let ``deserialize InternalTag NamedFields`` () =
+        Assert.Equal(Ba, JsonSerializer.Deserialize("""{"Case":"Ba"}""", internalTagNamedFieldsOptions))
+        Assert.Equal(Bb 32, JsonSerializer.Deserialize("""{"Case":"Bb","Item":32}""", internalTagNamedFieldsOptions))
+        Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"Case":"Bc","x":"test","Item2":true}""", internalTagNamedFieldsOptions))
+
+    [<Fact>]
+    let ``serialize InternalTag NamedFields`` () =
+        Assert.Equal("""{"Case":"Ba"}""", JsonSerializer.Serialize(Ba, internalTagNamedFieldsOptions))
+        Assert.Equal("""{"Case":"Bb","Item":32}""", JsonSerializer.Serialize(Bb 32, internalTagNamedFieldsOptions))
+        Assert.Equal("""{"Case":"Bc","x":"test","Item2":true}""", JsonSerializer.Serialize(Bc("test", true), internalTagNamedFieldsOptions))

--- a/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
@@ -59,6 +59,24 @@ module NonStruct =
         Assert.Equal("""null""", JsonSerializer.Serialize(Ca, options))
         Assert.Equal("""{"Case":"Cb","Fields":[32]}""", JsonSerializer.Serialize(Cb 32, options))
 
+    [<JsonFSharpConverter(JsonUnionEncoding.ExternalTag)>]
+    type D =
+        | Da
+        | Db of int
+        | Dc of string * bool
+
+    [<Fact>]
+    let ``deserialize ExternalTag`` () =
+        Assert.Equal(Da, JsonSerializer.Deserialize """{"Da":[]}""")
+        Assert.Equal(Db 32, JsonSerializer.Deserialize """{"Db":[32]}""")
+        Assert.Equal(Dc("test", true), JsonSerializer.Deserialize """{"Dc":["test",true]}""")
+
+    [<Fact>]
+    let ``serialize ExternalTag`` () =
+        Assert.Equal("""{"Da":[]}""", JsonSerializer.Serialize Da)
+        Assert.Equal("""{"Db":[32]}""", JsonSerializer.Serialize(Db 32))
+        Assert.Equal("""{"Dc":["test",true]}""", JsonSerializer.Serialize(Dc("test", true)))
+
 module Struct =
 
     [<Struct; JsonFSharpConverter>]
@@ -99,3 +117,21 @@ module Struct =
         Assert.Equal("""{"Case":"Ba"}""", JsonSerializer.Serialize(Ba, options))
         Assert.Equal("""{"Case":"Bb","Fields":[32]}""", JsonSerializer.Serialize(Bb 32, options))
         Assert.Equal("""{"Case":"Bc","Fields":["test",true]}""", JsonSerializer.Serialize(Bc("test", true), options))
+
+    [<Struct; JsonFSharpConverter(JsonUnionEncoding.ExternalTag)>]
+    type D =
+        | Da
+        | Db of int
+        | Dc of string * bool
+
+    [<Fact>]
+    let ``deserialize ExternalTag`` () =
+        Assert.Equal(Da, JsonSerializer.Deserialize """{"Da":[]}""")
+        Assert.Equal(Db 32, JsonSerializer.Deserialize """{"Db":[32]}""")
+        Assert.Equal(Dc("test", true), JsonSerializer.Deserialize """{"Dc":["test",true]}""")
+
+    [<Fact>]
+    let ``serialize ExternalTag`` () =
+        Assert.Equal("""{"Da":[]}""", JsonSerializer.Serialize Da)
+        Assert.Equal("""{"Db":[32]}""", JsonSerializer.Serialize(Db 32))
+        Assert.Equal("""{"Dc":["test",true]}""", JsonSerializer.Serialize(Dc("test", true)))

--- a/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
@@ -59,41 +59,35 @@ module NonStruct =
         Assert.Equal("""null""", JsonSerializer.Serialize(Ca, options))
         Assert.Equal("""{"Case":"Cb","Fields":[32]}""", JsonSerializer.Serialize(Cb 32, options))
 
-    [<JsonFSharpConverter(JsonUnionEncoding.ExternalTag)>]
-    type D =
-        | Da
-        | Db of int
-        | Dc of string * bool
+    let externalTagOptions = JsonSerializerOptions()
+    externalTagOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.ExternalTag))
 
     [<Fact>]
     let ``deserialize ExternalTag`` () =
-        Assert.Equal(Da, JsonSerializer.Deserialize """{"Da":[]}""")
-        Assert.Equal(Db 32, JsonSerializer.Deserialize """{"Db":[32]}""")
-        Assert.Equal(Dc("test", true), JsonSerializer.Deserialize """{"Dc":["test",true]}""")
+        Assert.Equal(Ba, JsonSerializer.Deserialize("""{"Ba":[]}""", externalTagOptions))
+        Assert.Equal(Bb 32, JsonSerializer.Deserialize("""{"Bb":[32]}""", externalTagOptions))
+        Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"Bc":["test",true]}""", externalTagOptions))
 
     [<Fact>]
     let ``serialize ExternalTag`` () =
-        Assert.Equal("""{"Da":[]}""", JsonSerializer.Serialize Da)
-        Assert.Equal("""{"Db":[32]}""", JsonSerializer.Serialize(Db 32))
-        Assert.Equal("""{"Dc":["test",true]}""", JsonSerializer.Serialize(Dc("test", true)))
+        Assert.Equal("""{"Ba":[]}""", JsonSerializer.Serialize(Ba, externalTagOptions))
+        Assert.Equal("""{"Bb":[32]}""", JsonSerializer.Serialize(Bb 32, externalTagOptions))
+        Assert.Equal("""{"Bc":["test",true]}""", JsonSerializer.Serialize(Bc("test", true), externalTagOptions))
 
-    [<JsonFSharpConverter(JsonUnionEncoding.InternalTag)>]
-    type E =
-        | Ea
-        | Eb of int
-        | Ec of string * bool
+    let internalTagOptions = JsonSerializerOptions()
+    internalTagOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.InternalTag))
 
     [<Fact>]
     let ``deserialize InternalTag`` () =
-        Assert.Equal(Ea, JsonSerializer.Deserialize """["Ea"]""")
-        Assert.Equal(Eb 32, JsonSerializer.Deserialize """["Eb",32]""")
-        Assert.Equal(Ec("test", true), JsonSerializer.Deserialize """["Ec","test",true]""")
+        Assert.Equal(Ba, JsonSerializer.Deserialize("""["Ba"]""", internalTagOptions))
+        Assert.Equal(Bb 32, JsonSerializer.Deserialize("""["Bb",32]""", internalTagOptions))
+        Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""["Bc","test",true]""", internalTagOptions))
 
     [<Fact>]
     let ``serialize InternalTag`` () =
-        Assert.Equal("""["Ea"]""", JsonSerializer.Serialize Ea)
-        Assert.Equal("""["Eb",32]""", JsonSerializer.Serialize(Eb 32))
-        Assert.Equal("""["Ec","test",true]""", JsonSerializer.Serialize(Ec("test", true)))
+        Assert.Equal("""["Ba"]""", JsonSerializer.Serialize(Ba, internalTagOptions))
+        Assert.Equal("""["Bb",32]""", JsonSerializer.Serialize(Bb 32, internalTagOptions))
+        Assert.Equal("""["Bc","test",true]""", JsonSerializer.Serialize(Bc("test", true), internalTagOptions))
 
 module Struct =
 
@@ -136,38 +130,32 @@ module Struct =
         Assert.Equal("""{"Case":"Bb","Fields":[32]}""", JsonSerializer.Serialize(Bb 32, options))
         Assert.Equal("""{"Case":"Bc","Fields":["test",true]}""", JsonSerializer.Serialize(Bc("test", true), options))
 
-    [<Struct; JsonFSharpConverter(JsonUnionEncoding.ExternalTag)>]
-    type D =
-        | Da
-        | Db of int
-        | Dc of string * bool
+    let externalTagOptions = JsonSerializerOptions()
+    externalTagOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.ExternalTag))
 
     [<Fact>]
     let ``deserialize ExternalTag`` () =
-        Assert.Equal(Da, JsonSerializer.Deserialize """{"Da":[]}""")
-        Assert.Equal(Db 32, JsonSerializer.Deserialize """{"Db":[32]}""")
-        Assert.Equal(Dc("test", true), JsonSerializer.Deserialize """{"Dc":["test",true]}""")
+        Assert.Equal(Ba, JsonSerializer.Deserialize("""{"Ba":[]}""", externalTagOptions))
+        Assert.Equal(Bb 32, JsonSerializer.Deserialize("""{"Bb":[32]}""", externalTagOptions))
+        Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"Bc":["test",true]}""", externalTagOptions))
 
     [<Fact>]
     let ``serialize ExternalTag`` () =
-        Assert.Equal("""{"Da":[]}""", JsonSerializer.Serialize Da)
-        Assert.Equal("""{"Db":[32]}""", JsonSerializer.Serialize(Db 32))
-        Assert.Equal("""{"Dc":["test",true]}""", JsonSerializer.Serialize(Dc("test", true)))
+        Assert.Equal("""{"Ba":[]}""", JsonSerializer.Serialize(Ba, externalTagOptions))
+        Assert.Equal("""{"Bb":[32]}""", JsonSerializer.Serialize(Bb 32, externalTagOptions))
+        Assert.Equal("""{"Bc":["test",true]}""", JsonSerializer.Serialize(Bc("test", true), externalTagOptions))
 
-    [<Struct; JsonFSharpConverter(JsonUnionEncoding.InternalTag)>]
-    type E =
-        | Ea
-        | Eb of int
-        | Ec of string * bool
+    let internalTagOptions = JsonSerializerOptions()
+    internalTagOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.InternalTag))
 
     [<Fact>]
     let ``deserialize InternalTag`` () =
-        Assert.Equal(Ea, JsonSerializer.Deserialize """["Ea"]""")
-        Assert.Equal(Eb 32, JsonSerializer.Deserialize """["Eb",32]""")
-        Assert.Equal(Ec("test", true), JsonSerializer.Deserialize """["Ec","test",true]""")
+        Assert.Equal(Ba, JsonSerializer.Deserialize("""["Ba"]""", internalTagOptions))
+        Assert.Equal(Bb 32, JsonSerializer.Deserialize("""["Bb",32]""", internalTagOptions))
+        Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""["Bc","test",true]""", internalTagOptions))
 
     [<Fact>]
     let ``serialize InternalTag`` () =
-        Assert.Equal("""["Ea"]""", JsonSerializer.Serialize Ea)
-        Assert.Equal("""["Eb",32]""", JsonSerializer.Serialize(Eb 32))
-        Assert.Equal("""["Ec","test",true]""", JsonSerializer.Serialize(Ec("test", true)))
+        Assert.Equal("""["Ba"]""", JsonSerializer.Serialize(Ba, internalTagOptions))
+        Assert.Equal("""["Bb",32]""", JsonSerializer.Serialize(Bb 32, internalTagOptions))
+        Assert.Equal("""["Bc","test",true]""", JsonSerializer.Serialize(Bc("test", true), internalTagOptions))

--- a/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
@@ -89,6 +89,21 @@ module NonStruct =
         Assert.Equal("""["Bb",32]""", JsonSerializer.Serialize(Bb 32, internalTagOptions))
         Assert.Equal("""["Bc","test",true]""", JsonSerializer.Serialize(Bc("test", true), internalTagOptions))
 
+    let untaggedOptions = JsonSerializerOptions()
+    untaggedOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.Untagged))
+
+    [<Fact>]
+    let ``deserialize Untagged`` () =
+        Assert.Equal(Ba, JsonSerializer.Deserialize("""{}""", untaggedOptions))
+        Assert.Equal(Bb 32, JsonSerializer.Deserialize("""{"Item":32}""", untaggedOptions))
+        Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"x":"test","Item2":true}""", untaggedOptions))
+
+    [<Fact>]
+    let ``serialize Untagged`` () =
+        Assert.Equal("""{}""", JsonSerializer.Serialize(Ba, untaggedOptions))
+        Assert.Equal("""{"Item":32}""", JsonSerializer.Serialize(Bb 32, untaggedOptions))
+        Assert.Equal("""{"x":"test","Item2":true}""", JsonSerializer.Serialize(Bc("test", true), untaggedOptions))
+
     let adjacentTagNamedFieldsOptions = JsonSerializerOptions()
     adjacentTagNamedFieldsOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.AdjacentTag ||| JsonUnionEncoding.NamedFields))
 
@@ -204,6 +219,36 @@ module Struct =
         Assert.Equal("""["Ba"]""", JsonSerializer.Serialize(Ba, internalTagOptions))
         Assert.Equal("""["Bb",32]""", JsonSerializer.Serialize(Bb 32, internalTagOptions))
         Assert.Equal("""["Bc","test",true]""", JsonSerializer.Serialize(Bc("test", true), internalTagOptions))
+
+    let untaggedOptions = JsonSerializerOptions()
+    untaggedOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.Untagged))
+
+    [<Fact>]
+    let ``deserialize Untagged`` () =
+        Assert.Equal(Ba, JsonSerializer.Deserialize("""{}""", untaggedOptions))
+        Assert.Equal(Bb 32, JsonSerializer.Deserialize("""{"Item":32}""", untaggedOptions))
+        Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"x":"test","Item2":true}""", untaggedOptions))
+
+    [<Fact>]
+    let ``serialize Untagged`` () =
+        Assert.Equal("""{}""", JsonSerializer.Serialize(Ba, untaggedOptions))
+        Assert.Equal("""{"Item":32}""", JsonSerializer.Serialize(Bb 32, untaggedOptions))
+        Assert.Equal("""{"x":"test","Item2":true}""", JsonSerializer.Serialize(Bc("test", true), untaggedOptions))
+
+    let adjacentTagNamedFieldsOptions = JsonSerializerOptions()
+    adjacentTagNamedFieldsOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.AdjacentTag ||| JsonUnionEncoding.NamedFields))
+
+    [<Fact>]
+    let ``deserialize AdjacentTag NamedFields`` () =
+        Assert.Equal(Ba, JsonSerializer.Deserialize("""{"Case":"Ba"}""", adjacentTagNamedFieldsOptions))
+        Assert.Equal(Bb 32, JsonSerializer.Deserialize("""{"Case":"Bb","Fields":{"Item":32}}""", adjacentTagNamedFieldsOptions))
+        Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"Case":"Bc","Fields":{"x":"test","Item2":true}}""", adjacentTagNamedFieldsOptions))
+
+    [<Fact>]
+    let ``serialize AdjacentTag NamedFields`` () =
+        Assert.Equal("""{"Case":"Ba"}""", JsonSerializer.Serialize(Ba, adjacentTagNamedFieldsOptions))
+        Assert.Equal("""{"Case":"Bb","Fields":{"Item":32}}""", JsonSerializer.Serialize(Bb 32, adjacentTagNamedFieldsOptions))
+        Assert.Equal("""{"Case":"Bc","Fields":{"x":"test","Item2":true}}""", JsonSerializer.Serialize(Bc("test", true), adjacentTagNamedFieldsOptions))
 
     let externalTagNamedFieldsOptions = JsonSerializerOptions()
     externalTagNamedFieldsOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.ExternalTag ||| JsonUnionEncoding.NamedFields))

--- a/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
@@ -77,6 +77,24 @@ module NonStruct =
         Assert.Equal("""{"Db":[32]}""", JsonSerializer.Serialize(Db 32))
         Assert.Equal("""{"Dc":["test",true]}""", JsonSerializer.Serialize(Dc("test", true)))
 
+    [<JsonFSharpConverter(JsonUnionEncoding.InternalTag)>]
+    type E =
+        | Ea
+        | Eb of int
+        | Ec of string * bool
+
+    [<Fact>]
+    let ``deserialize InternalTag`` () =
+        Assert.Equal(Ea, JsonSerializer.Deserialize """["Ea"]""")
+        Assert.Equal(Eb 32, JsonSerializer.Deserialize """["Eb",32]""")
+        Assert.Equal(Ec("test", true), JsonSerializer.Deserialize """["Ec","test",true]""")
+
+    [<Fact>]
+    let ``serialize InternalTag`` () =
+        Assert.Equal("""["Ea"]""", JsonSerializer.Serialize Ea)
+        Assert.Equal("""["Eb",32]""", JsonSerializer.Serialize(Eb 32))
+        Assert.Equal("""["Ec","test",true]""", JsonSerializer.Serialize(Ec("test", true)))
+
 module Struct =
 
     [<Struct; JsonFSharpConverter>]
@@ -135,3 +153,21 @@ module Struct =
         Assert.Equal("""{"Da":[]}""", JsonSerializer.Serialize Da)
         Assert.Equal("""{"Db":[32]}""", JsonSerializer.Serialize(Db 32))
         Assert.Equal("""{"Dc":["test",true]}""", JsonSerializer.Serialize(Dc("test", true)))
+
+    [<Struct; JsonFSharpConverter(JsonUnionEncoding.InternalTag)>]
+    type E =
+        | Ea
+        | Eb of int
+        | Ec of string * bool
+
+    [<Fact>]
+    let ``deserialize InternalTag`` () =
+        Assert.Equal(Ea, JsonSerializer.Deserialize """["Ea"]""")
+        Assert.Equal(Eb 32, JsonSerializer.Deserialize """["Eb",32]""")
+        Assert.Equal(Ec("test", true), JsonSerializer.Deserialize """["Ec","test",true]""")
+
+    [<Fact>]
+    let ``serialize InternalTag`` () =
+        Assert.Equal("""["Ea"]""", JsonSerializer.Serialize Ea)
+        Assert.Equal("""["Eb",32]""", JsonSerializer.Serialize(Eb 32))
+        Assert.Equal("""["Ec","test",true]""", JsonSerializer.Serialize(Ec("test", true)))


### PR DESCRIPTION
Encodings implemented:

* [x] `AdjacentTag`
* [x] `AdjacentTag ||| NamedFields`
* [x] `ExternalTag`
* [x] `ExternalTag ||| NamedFields`
* [x] `InternalTag`
* [x] `InternalTag ||| NamedFields`
* [x] `Untagged`
* [x] `BareFieldlessTags`