### PR TITLE
Add support for changing the internal tag name

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,11 +180,30 @@ options.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.InternalTag ||| Jso
 type MyUnion = // ...
 ```
 
+Some of the encoding styles for Unions write their union case name to a configurable tag. To configure this, `JsonFSharpConverter` accepts an argument called `unionTagName`. This tag defaults to `"Case"`, and can be configured like so:
+
+```fsharp
+// Using options:
+let options = JsonSerializerOptions()
+options.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.AdjacentTag ||| JsonUnionEncoding.NamedFields, "alternative-case-tag"))
+
+// Using attributes:
+[<JsonFSharpConverter(JsonUnionEncoding.AdjacentTag ||| JsonUnionEncoding.NamedFields, "alternative-case-tag")>]
+type MyUnion = // ...
+```
+
+Note that when using the default `JsonUnionEncoding`, `unionTagName` needs to be passed by key, rather than by position, e.g.:
+
+``` fsharp
+[<JsonFSharpConverter(unionTagName="alternative-case-tag")>]
+type MyUnion = // ...
+```
+
 Here are the possible values:
 
 * `JsonUnionEncoding.AdjacentTag` is the default format. It represents unions as a JSON object with two fields:
 
-    * `"Case"`: a string whose value is the name of the union case.
+    * A tag, defaulting to `"Case"`: a string whose value is the name of the union case.
     * `"Fields"`: an array whose items are the arguments of the union case. This field is absent if the union case has no arguments.
 
     This is the same format used by Newtonsoft.Json.
@@ -245,7 +264,7 @@ Here are the possible values:
     // --> ["WithArgs",123,"Hello world!"]
     ```
 
-* `JsonUnionEncoding.InternalTag ||| JsonUnionEncoding.NamedFields` represents unions as an object whose first field has name `"Case"` and value the name of the case, and the rest of the fields have the names and values of the arguments.
+* `JsonUnionEncoding.InternalTag ||| JsonUnionEncoding.NamedFields` represents unions as an object whose first field is `unionTagName` (defaulting to  `"Case"`), and whose value is the name of the case. The rest of the fields have the names and values of the arguments.
 
     ```fsharp
     JsonSerializer.Serialize(NoArgs, options)

--- a/src/FSharp.SystemTextJson/All.fs
+++ b/src/FSharp.SystemTextJson/All.fs
@@ -8,7 +8,7 @@ type JsonFSharpConverter
         [<Optional; DefaultParameterValue(JsonUnionEncoding.Default)>]
         unionEncoding: JsonUnionEncoding,
         [<Optional; DefaultParameterValue("Case")>]
-        unionInternalTagName: JsonUnionInternalTagName
+        unionTagName: JsonUnionTagName
     ) =
     inherit JsonConverterFactory()
 
@@ -20,7 +20,7 @@ type JsonFSharpConverter
         JsonRecordConverter.CanConvert(typeToConvert) ||
         JsonUnionConverter.CanConvert(typeToConvert)
 
-    static member internal CreateConverter(typeToConvert, unionEncoding, unionInternalTagName) =
+    static member internal CreateConverter(typeToConvert, unionEncoding, unionTagName) =
         if JsonListConverter.CanConvert(typeToConvert) then
             JsonListConverter.CreateConverter(typeToConvert)
         elif JsonSetConverter.CanConvert(typeToConvert) then
@@ -32,12 +32,12 @@ type JsonFSharpConverter
         elif JsonRecordConverter.CanConvert(typeToConvert) then
             JsonRecordConverter.CreateConverter(typeToConvert)
         elif JsonUnionConverter.CanConvert(typeToConvert) then
-            JsonUnionConverter.CreateConverter(typeToConvert, unionEncoding, unionInternalTagName)
+            JsonUnionConverter.CreateConverter(typeToConvert, unionEncoding, unionTagName)
         else
             invalidOp ("Not an F# record or union type: " + typeToConvert.FullName)
 
     override this.CreateConverter(typeToConvert, _options) =
-        JsonFSharpConverter.CreateConverter(typeToConvert, unionEncoding, unionInternalTagName)
+        JsonFSharpConverter.CreateConverter(typeToConvert, unionEncoding, unionTagName)
 
 [<AttributeUsage(AttributeTargets.Class ||| AttributeTargets.Struct)>]
 type JsonFSharpConverterAttribute
@@ -45,9 +45,9 @@ type JsonFSharpConverterAttribute
         [<Optional; DefaultParameterValue(JsonUnionEncoding.Default)>]
         unionEncoding: JsonUnionEncoding,
         [<Optional; DefaultParameterValue("Case")>]
-        unionInternalTagName: JsonUnionInternalTagName
+        unionTagName: JsonUnionTagName
     ) =
     inherit JsonConverterAttribute()
 
     override __.CreateConverter(typeToConvert) =
-        JsonFSharpConverter.CreateConverter(typeToConvert, unionEncoding, unionInternalTagName)
+        JsonFSharpConverter.CreateConverter(typeToConvert, unionEncoding, unionTagName)

--- a/src/FSharp.SystemTextJson/All.fs
+++ b/src/FSharp.SystemTextJson/All.fs
@@ -6,7 +6,9 @@ open System.Runtime.InteropServices
 type JsonFSharpConverter
     (
         [<Optional; DefaultParameterValue(JsonUnionEncoding.Default)>]
-        unionEncoding: JsonUnionEncoding
+        unionEncoding: JsonUnionEncoding,
+        [<Optional; DefaultParameterValue("Case")>]
+        unionInternalTagName: JsonUnionInternalTagName
     ) =
     inherit JsonConverterFactory()
 
@@ -18,7 +20,7 @@ type JsonFSharpConverter
         JsonRecordConverter.CanConvert(typeToConvert) ||
         JsonUnionConverter.CanConvert(typeToConvert)
 
-    static member internal CreateConverter(typeToConvert, unionEncoding) =
+    static member internal CreateConverter(typeToConvert, unionEncoding, unionInternalTagName) =
         if JsonListConverter.CanConvert(typeToConvert) then
             JsonListConverter.CreateConverter(typeToConvert)
         elif JsonSetConverter.CanConvert(typeToConvert) then
@@ -30,20 +32,22 @@ type JsonFSharpConverter
         elif JsonRecordConverter.CanConvert(typeToConvert) then
             JsonRecordConverter.CreateConverter(typeToConvert)
         elif JsonUnionConverter.CanConvert(typeToConvert) then
-            JsonUnionConverter.CreateConverter(typeToConvert, unionEncoding)
+            JsonUnionConverter.CreateConverter(typeToConvert, unionEncoding, unionInternalTagName)
         else
             invalidOp ("Not an F# record or union type: " + typeToConvert.FullName)
 
     override this.CreateConverter(typeToConvert, _options) =
-        JsonFSharpConverter.CreateConverter(typeToConvert, unionEncoding)
+        JsonFSharpConverter.CreateConverter(typeToConvert, unionEncoding, unionInternalTagName)
 
 [<AttributeUsage(AttributeTargets.Class ||| AttributeTargets.Struct)>]
 type JsonFSharpConverterAttribute
     (
         [<Optional; DefaultParameterValue(JsonUnionEncoding.Default)>]
-        unionEncoding: JsonUnionEncoding
+        unionEncoding: JsonUnionEncoding,
+        [<Optional; DefaultParameterValue("Case")>]
+        unionInternalTagName: JsonUnionInternalTagName
     ) =
     inherit JsonConverterAttribute()
 
     override __.CreateConverter(typeToConvert) =
-        JsonFSharpConverter.CreateConverter(typeToConvert, unionEncoding)
+        JsonFSharpConverter.CreateConverter(typeToConvert, unionEncoding, unionInternalTagName)

--- a/src/FSharp.SystemTextJson/Union.fs
+++ b/src/FSharp.SystemTextJson/Union.fs
@@ -47,6 +47,8 @@ type JsonUnionEncoding =
     | ThothLike         = 0x02_04
 
 
+type JsonUnionInternalTagName = string
+
 type private Case =
     {
         Info: UnionCaseInfo
@@ -55,7 +57,7 @@ type private Case =
         Dector: obj -> obj[]
     }
 
-type JsonUnionConverter<'T>(encoding: JsonUnionEncoding) =
+type JsonUnionConverter<'T>(encoding: JsonUnionEncoding, internalTagName: JsonUnionInternalTagName) =
     inherit JsonConverter<'T>()
 
     let [<Literal>] UntaggedBit = enum<JsonUnionEncoding> 0x00_08
@@ -103,9 +105,9 @@ type JsonUnionConverter<'T>(encoding: JsonUnionEncoding) =
                 if hasDuplicateFieldNames then
                     foundFieldNames
                 else
-                    if foundFieldNames |> Map.containsKey fieldName then
-                        hasDuplicateFieldNames <- true
-                    Map.add fieldName case foundFieldNames)
+                if foundFieldNames |> Map.containsKey fieldName then
+                    hasDuplicateFieldNames <- true
+                Map.add fieldName case foundFieldNames)
         let fields = [| for KeyValue(k, v) in fields -> struct (k, v) |]
         not hasDuplicateFieldNames, fieldlessCase, fields
 
@@ -158,7 +160,7 @@ type JsonUnionConverter<'T>(encoding: JsonUnionEncoding) =
             fields.[i] <- JsonSerializer.Deserialize(&reader, case.Fields.[i].PropertyType, options)
         readExpecting JsonTokenType.EndArray "end of array" &reader ty
         case.Ctor fields :?> 'T
-    
+
     static let readFieldsAsArray (reader: byref<Utf8JsonReader>) (case: Case) (options: JsonSerializerOptions) =
         readExpecting JsonTokenType.StartArray "array" &reader ty
         readFieldsAsRestOfArray &reader case options
@@ -199,7 +201,7 @@ type JsonUnionConverter<'T>(encoding: JsonUnionEncoding) =
 
     let readAdjacentTag (reader: byref<Utf8JsonReader>) (options: JsonSerializerOptions) =
         expectAlreadyRead JsonTokenType.StartObject "object" &reader ty
-        readExpectingPropertyNamed "Case" &reader ty
+        readExpectingPropertyNamed internalTagName &reader ty
         readExpecting JsonTokenType.String "case name" &reader ty
         let case = getCaseByTag &reader
         let res =
@@ -222,7 +224,7 @@ type JsonUnionConverter<'T>(encoding: JsonUnionEncoding) =
     let readInternalTag (reader: byref<Utf8JsonReader>) (options: JsonSerializerOptions) =
         if namedFields then
             expectAlreadyRead JsonTokenType.StartObject "object" &reader ty
-            readExpectingPropertyNamed "Case" &reader ty
+            readExpectingPropertyNamed internalTagName &reader ty
             readExpecting JsonTokenType.String "case name" &reader ty
             let case = getCaseByTag &reader
             readFieldsAsRestOfObject &reader case false options
@@ -275,7 +277,7 @@ type JsonUnionConverter<'T>(encoding: JsonUnionEncoding) =
 
     let writeAdjacentTag (writer: Utf8JsonWriter) (case: Case) (value: obj) (options: JsonSerializerOptions) =
         writer.WriteStartObject()
-        writer.WriteString("Case", case.Info.Name)
+        writer.WriteString(internalTagName, case.Info.Name)
         if case.Fields.Length > 0 then
             writer.WritePropertyName("Fields")
             writeFields writer case value options
@@ -290,7 +292,7 @@ type JsonUnionConverter<'T>(encoding: JsonUnionEncoding) =
     let writeInternalTag (writer: Utf8JsonWriter) (case: Case) (value: obj) (options: JsonSerializerOptions) =
         if namedFields then
             writer.WriteStartObject()
-            writer.WriteString("Case", case.Info.Name)
+            writer.WriteString(internalTagName, case.Info.Name)
             writeFieldsAsRestOfObject writer case value options
         else
             writer.WriteStartArray()
@@ -338,25 +340,28 @@ type JsonUnionConverter<'T>(encoding: JsonUnionEncoding) =
 type JsonUnionConverter
     (
         [<Optional; DefaultParameterValue(JsonUnionEncoding.Default)>]
-        encoding: JsonUnionEncoding
+        encoding: JsonUnionEncoding,
+        [<Optional; DefaultParameterValue("Case")>]
+        internalTagName: JsonUnionInternalTagName
     ) =
     inherit JsonConverterFactory()
 
     static let jsonUnionConverterTy = typedefof<JsonUnionConverter<_>>
     static let jsonUnionEncodingTy = typeof<JsonUnionEncoding>
+    static let internalTagNameTy = typeof<JsonUnionInternalTagName>
 
     static member internal CanConvert(typeToConvert) =
         TypeCache.isUnion typeToConvert
 
-    static member internal CreateConverter(typeToConvert, encoding: JsonUnionEncoding) =
+    static member internal CreateConverter(typeToConvert, encoding: JsonUnionEncoding, internalTagName: JsonUnionInternalTagName) =
         jsonUnionConverterTy
             .MakeGenericType([|typeToConvert|])
-            .GetConstructor([|jsonUnionEncodingTy|])
-            .Invoke([|encoding|])
+            .GetConstructor([|jsonUnionEncodingTy; internalTagNameTy|])
+            .Invoke([|encoding; internalTagName|])
         :?> JsonConverter
 
     override this.CanConvert(typeToConvert) =
         JsonUnionConverter.CanConvert(typeToConvert)
 
     override this.CreateConverter(typeToConvert, _options) =
-        JsonUnionConverter.CreateConverter(typeToConvert, encoding)
+        JsonUnionConverter.CreateConverter(typeToConvert, encoding, internalTagName)

--- a/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
@@ -149,6 +149,21 @@ module NonStruct =
         Assert.Equal("""{"Case":"Bb","Item":32}""", JsonSerializer.Serialize(Bb 32, internalTagNamedFieldsOptions))
         Assert.Equal("""{"Case":"Bc","x":"test","Item2":true}""", JsonSerializer.Serialize(Bc("test", true), internalTagNamedFieldsOptions))
 
+    let internalTagNamedFieldsConfiguredTagOptions = JsonSerializerOptions()
+    internalTagNamedFieldsConfiguredTagOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.InternalTag ||| JsonUnionEncoding.NamedFields, "type"))
+
+    [<Fact>]
+    let ``deserialize InternalTag NamedFields alternative Tag`` () =
+        Assert.Equal(Ba, JsonSerializer.Deserialize("""{"type":"Ba"}""", internalTagNamedFieldsConfiguredTagOptions))
+        Assert.Equal(Bb 32, JsonSerializer.Deserialize("""{"type":"Bb","Item":32}""", internalTagNamedFieldsConfiguredTagOptions))
+        Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"type":"Bc","x":"test","Item2":true}""", internalTagNamedFieldsConfiguredTagOptions))
+
+    [<Fact>]
+    let ``serialize InternalTag NamedFields alternative Tag`` () =
+        Assert.Equal("""{"type":"Ba"}""", JsonSerializer.Serialize(Ba, internalTagNamedFieldsConfiguredTagOptions))
+        Assert.Equal("""{"type":"Bb","Item":32}""", JsonSerializer.Serialize(Bb 32, internalTagNamedFieldsConfiguredTagOptions))
+        Assert.Equal("""{"type":"Bc","x":"test","Item2":true}""", JsonSerializer.Serialize(Bc("test", true), internalTagNamedFieldsConfiguredTagOptions))
+
     let bareFieldlessTagsOptions = JsonSerializerOptions()
     bareFieldlessTagsOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.BareFieldlessTags))
 
@@ -296,6 +311,21 @@ module Struct =
         Assert.Equal("""{"Case":"Ba"}""", JsonSerializer.Serialize(Ba, internalTagNamedFieldsOptions))
         Assert.Equal("""{"Case":"Bb","Item":32}""", JsonSerializer.Serialize(Bb 32, internalTagNamedFieldsOptions))
         Assert.Equal("""{"Case":"Bc","x":"test","Item2":true}""", JsonSerializer.Serialize(Bc("test", true), internalTagNamedFieldsOptions))
+
+    let internalTagNamedFieldsConfiguredTagOptions = JsonSerializerOptions()
+    internalTagNamedFieldsConfiguredTagOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.InternalTag ||| JsonUnionEncoding.NamedFields, "type"))
+
+    [<Fact>]
+    let ``deserialize InternalTag NamedFields alternative Tag`` () =
+        Assert.Equal(Ba, JsonSerializer.Deserialize("""{"type":"Ba"}""", internalTagNamedFieldsConfiguredTagOptions))
+        Assert.Equal(Bb 32, JsonSerializer.Deserialize("""{"type":"Bb","Item":32}""", internalTagNamedFieldsConfiguredTagOptions))
+        Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"type":"Bc","x":"test","Item2":true}""", internalTagNamedFieldsConfiguredTagOptions))
+
+    [<Fact>]
+    let ``serialize InternalTag NamedFields alternative Tag`` () =
+        Assert.Equal("""{"type":"Ba"}""", JsonSerializer.Serialize(Ba, internalTagNamedFieldsConfiguredTagOptions))
+        Assert.Equal("""{"type":"Bb","Item":32}""", JsonSerializer.Serialize(Bb 32, internalTagNamedFieldsConfiguredTagOptions))
+        Assert.Equal("""{"type":"Bc","x":"test","Item2":true}""", JsonSerializer.Serialize(Bc("test", true), internalTagNamedFieldsConfiguredTagOptions))
 
     let bareFieldlessTagsOptions = JsonSerializerOptions()
     bareFieldlessTagsOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.BareFieldlessTags))


### PR DESCRIPTION
Previously, the `InternalTag` scheme hard-coded the tag name to be "Case". This PR makes the tag name configurable, but codes "Case" as the default, which should make this change fully backwards-compatible. This is done by adding a new argument to the set of `JsonFSharpConverter` constructors, along with a type alias to clarify what the argument does.

The original test suite passes, and four more test cases are added to be sure the new functionality
works.

This is... not a _naive_ approach per se, but it's a bit of a stab in the dark. I haven't yet updated the README, for instance, and don't want to until this approach has been reviewed and approved or updated. Very happy to switch approaches, too -- I'm not wed to this one. If this approach pleases, I'll push updates to the README + any other documents that need freshening. 