### PR TITLE
Enforce no nulls in record types unless type is FSharpOption

### DIFF
--- a/src/FSharp.SystemTextJson/All.fs
+++ b/src/FSharp.SystemTextJson/All.fs
@@ -20,7 +20,7 @@ type JsonFSharpConverter(fsOptions: JsonFSharpOptions) =
         elif JsonTupleConverter.CanConvert(typeToConvert) then
             JsonTupleConverter.CreateConverter(typeToConvert)
         elif JsonRecordConverter.CanConvert(typeToConvert) then
-            JsonRecordConverter.CreateConverter(typeToConvert, options)
+            JsonRecordConverter.CreateConverter(typeToConvert, options, fsOptions)
         elif JsonUnionConverter.CanConvert(typeToConvert) then
             JsonUnionConverter.CreateConverter(typeToConvert, options, fsOptions)
         else

--- a/src/FSharp.SystemTextJson/All.fs
+++ b/src/FSharp.SystemTextJson/All.fs
@@ -39,9 +39,11 @@ type JsonFSharpConverter(fsOptions: JsonFSharpOptions) =
             [<Optional; DefaultParameterValue(Default.UnionTagNamingPolicy)>]
             unionTagNamingPolicy: JsonNamingPolicy,
             [<Optional; DefaultParameterValue(Default.UnionTagCaseInsensitive)>]
-            unionTagCaseInsensitive: bool
+            unionTagCaseInsensitive: bool,
+            [<Optional; DefaultParameterValue(Default.AllowNullFields)>]
+            allowNullFields: bool
         ) =
-        JsonFSharpConverter(JsonFSharpOptions(unionEncoding, unionTagName, unionFieldsName, unionTagNamingPolicy, unionTagCaseInsensitive))
+        JsonFSharpConverter(JsonFSharpOptions(unionEncoding, unionTagName, unionFieldsName, unionTagNamingPolicy, unionTagCaseInsensitive, allowNullFields))
 
 [<AttributeUsage(AttributeTargets.Class ||| AttributeTargets.Struct)>]
 type JsonFSharpConverterAttribute
@@ -51,13 +53,17 @@ type JsonFSharpConverterAttribute
         [<Optional; DefaultParameterValue(Default.UnionTagName)>]
         unionTagName: JsonUnionTagName,
         [<Optional; DefaultParameterValue(Default.UnionFieldsName)>]
-        unionFieldsName: JsonUnionFieldsName
+        unionFieldsName: JsonUnionFieldsName,
+        [<Optional; DefaultParameterValue(Default.UnionTagCaseInsensitive)>]
+        unionTagCaseInsensitive: bool,
+        [<Optional; DefaultParameterValue(Default.AllowNullFields)>]
+        allowNullFields: bool
     ) =
     inherit JsonConverterAttribute()
 
     let options = JsonSerializerOptions()
 
-    let fsOptions = JsonFSharpOptions(unionEncoding, unionTagName, unionFieldsName, Default.UnionTagNamingPolicy)
+    let fsOptions = JsonFSharpOptions(unionEncoding, unionTagName, unionFieldsName, Default.UnionTagNamingPolicy, unionTagCaseInsensitive, allowNullFields)
 
     override _.CreateConverter(typeToConvert) =
         JsonFSharpConverter.CreateConverter(typeToConvert, options, fsOptions)

--- a/src/FSharp.SystemTextJson/Helpers.fs
+++ b/src/FSharp.SystemTextJson/Helpers.fs
@@ -21,7 +21,7 @@ let readExpectingPropertyNamed (expectedPropertyName: string) (reader: byref<Utf
     if not (reader.Read()) || reader.TokenType <> JsonTokenType.PropertyName || not (reader.ValueTextEquals expectedPropertyName) then
         fail ("\"" + expectedPropertyName + "\"") &reader ty
 
-let usesNull (ty: Type) =
+let isNullableUnion (ty: Type) =
     ty.GetCustomAttributes(typeof<CompilationRepresentationAttribute>, false)
     |> Array.exists (fun x ->
         let x = (x :?> CompilationRepresentationAttribute)

--- a/src/FSharp.SystemTextJson/Helpers.fs
+++ b/src/FSharp.SystemTextJson/Helpers.fs
@@ -20,3 +20,9 @@ let readExpecting expectedTokenType expectedLabel (reader: byref<Utf8JsonReader>
 let readExpectingPropertyNamed (expectedPropertyName: string) (reader: byref<Utf8JsonReader>) ty =
     if not (reader.Read()) || reader.TokenType <> JsonTokenType.PropertyName || not (reader.ValueTextEquals expectedPropertyName) then
         fail ("\"" + expectedPropertyName + "\"") &reader ty
+
+let usesNull (ty: Type) =
+    ty.GetCustomAttributes(typeof<CompilationRepresentationAttribute>, false)
+    |> Array.exists (fun x ->
+        let x = (x :?> CompilationRepresentationAttribute)
+        x.Flags.HasFlag(CompilationRepresentationFlags.UseNullAsTrueValue))

--- a/src/FSharp.SystemTextJson/Options.fs
+++ b/src/FSharp.SystemTextJson/Options.fs
@@ -70,6 +70,8 @@ module internal Default =
 
     let [<Literal>] UnionTagCaseInsensitive = false
 
+    let [<Literal>] AllowNullFields = false
+
 type JsonFSharpOptions
     (
         [<Optional; DefaultParameterValue(Default.UnionEncoding)>]
@@ -81,7 +83,9 @@ type JsonFSharpOptions
         [<Optional; DefaultParameterValue(Default.UnionTagNamingPolicy)>]
         unionTagNamingPolicy: JsonNamingPolicy,
         [<Optional; DefaultParameterValue(Default.UnionTagCaseInsensitive)>]
-        unionTagCaseInsensitive: bool
+        unionTagCaseInsensitive: bool,
+        [<Optional; DefaultParameterValue(Default.AllowNullFields)>]
+        allowNullFields: bool
     ) =
 
     member this.UnionEncoding = unionEncoding
@@ -93,3 +97,5 @@ type JsonFSharpOptions
     member this.UnionTagNamingPolicy = unionTagNamingPolicy
 
     member this.UnionTagCaseInsensitive = unionTagCaseInsensitive
+
+    member this.AllowNullFields = allowNullFields

--- a/src/FSharp.SystemTextJson/Record.fs
+++ b/src/FSharp.SystemTextJson/Record.fs
@@ -34,7 +34,8 @@ type JsonRecordConverter<'T>(options: JsonSerializerOptions, fsOptions: JsonFSha
                 |> Array.isEmpty
                 |> not
             let canBeNull =
-                isNullableUnion p.PropertyType
+                fsOptions.AllowNullFields
+                || isNullableUnion p.PropertyType
                 || (fsOptions.UnionEncoding.HasFlag JsonUnionEncoding.SuccinctOption
                     && p.PropertyType.IsGenericType
                     && p.PropertyType.GetGenericTypeDefinition() = typedefof<voption<_>>)

--- a/src/FSharp.SystemTextJson/Record.fs
+++ b/src/FSharp.SystemTextJson/Record.fs
@@ -85,6 +85,9 @@ type JsonRecordConverter<'T>(options: JsonSerializerOptions) =
                 | ValueSome (i, p) when not p.Ignore ->
                     fieldsFound <- fieldsFound + 1
                     fields.[i] <- JsonSerializer.Deserialize(&reader, p.Type, options)
+                    if fields.[i] = null && not (p.Type.Name.StartsWith("FSharpOption")) then
+                        let msg = sprintf "Record field '%s' is a non-optional field." p.Name
+                        raise (JsonException msg)
                 | _ ->
                     reader.Skip()
             | _ -> ()

--- a/src/FSharp.SystemTextJson/Record.fs
+++ b/src/FSharp.SystemTextJson/Record.fs
@@ -86,7 +86,7 @@ type JsonRecordConverter<'T>(options: JsonSerializerOptions) =
                     fieldsFound <- fieldsFound + 1
                     fields.[i] <- JsonSerializer.Deserialize(&reader, p.Type, options)
                     if fields.[i] = null && not (p.Type.Name.StartsWith("FSharpOption")) then
-                        let msg = sprintf "Record field '%s' is a non-optional field." p.Name
+                        let msg = sprintf "Record field '%s' in type '%s' cannot be null." p.Name typeToConvert.Name
                         raise (JsonException msg)
                 | _ ->
                     reader.Skip()

--- a/src/FSharp.SystemTextJson/Union.fs
+++ b/src/FSharp.SystemTextJson/Union.fs
@@ -342,7 +342,7 @@ type JsonUnionConverter<'T>(options: JsonSerializerOptions, fsOptions: JsonFShar
 
     override _.Read(reader, _typeToConvert, options) =
         match reader.TokenType with
-        | JsonTokenType.Null when Helpers.usesNull ty ->
+        | JsonTokenType.Null when Helpers.isNullableUnion ty ->
             (null : obj) :?> 'T
         | JsonTokenType.String when bareFieldlessTags ->
             let case = getCaseByTag &reader

--- a/src/FSharp.SystemTextJson/Union.fs
+++ b/src/FSharp.SystemTextJson/Union.fs
@@ -73,12 +73,6 @@ type JsonUnionConverter<'T>(options: JsonSerializerOptions, fsOptions: JsonFShar
 
     let tagReader = FSharpValue.PreComputeUnionTagReader(ty, true)
 
-    let usesNull =
-        ty.GetCustomAttributes(typeof<CompilationRepresentationAttribute>, false)
-        |> Array.exists (fun x ->
-            let x = (x :?> CompilationRepresentationAttribute)
-            x.Flags.HasFlag(CompilationRepresentationFlags.UseNullAsTrueValue))
-
     let hasDistinctFieldNames, fieldlessCase, allFields =
         let mutable fieldlessCase = ValueNone
         let mutable hasDuplicateFieldNames = false
@@ -348,7 +342,7 @@ type JsonUnionConverter<'T>(options: JsonSerializerOptions, fsOptions: JsonFShar
 
     override _.Read(reader, _typeToConvert, options) =
         match reader.TokenType with
-        | JsonTokenType.Null when usesNull ->
+        | JsonTokenType.Null when Helpers.usesNull ty ->
             (null : obj) :?> 'T
         | JsonTokenType.String when bareFieldlessTags ->
             let case = getCaseByTag &reader

--- a/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
@@ -47,6 +47,14 @@ module NonStruct =
         let actual = JsonSerializer.Serialize({bx=1;by="b"}, options)
         Assert.Equal("""{"bx":1,"by":"b"}""", actual)
 
+    [<Fact>]
+    let ``not fill in nulls`` () =
+        try
+            JsonSerializer.Deserialize<B>("""{"bx": 1, "by": null}""", options) |> ignore
+            failwith "Deserialization was supposed to fail on the line above"
+        with
+        | :? JsonException as e -> Assert.Equal("Record field 'by' is a non-optional field.", e.Message)
+
     type C =
         {
             cx: B

--- a/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
@@ -53,7 +53,7 @@ module NonStruct =
             JsonSerializer.Deserialize<B>("""{"bx": 1, "by": null}""", options) |> ignore
             failwith "Deserialization was supposed to fail on the line above"
         with
-        | :? JsonException as e -> Assert.Equal("Record field 'by' in type 'B' cannot be null.", e.Message)
+        | :? JsonException as e -> Assert.Equal("B.by was expected to be of type String, but was null.", e.Message)
 
     type C =
         {

--- a/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
@@ -55,6 +55,13 @@ module NonStruct =
         with
         | :? JsonException as e -> Assert.Equal("B.by was expected to be of type String, but was null.", e.Message)
 
+    [<Fact>]
+    let ``allowNullFields`` () =
+        let options = JsonSerializerOptions()
+        options.Converters.Add(JsonFSharpConverter(allowNullFields = true))
+        let actual = JsonSerializer.Deserialize("""{"bx":1,"by":null}""", options)
+        Assert.Equal({bx=1;by=null}, actual)
+
     type C =
         {
             cx: B

--- a/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
@@ -53,7 +53,7 @@ module NonStruct =
             JsonSerializer.Deserialize<B>("""{"bx": 1, "by": null}""", options) |> ignore
             failwith "Deserialization was supposed to fail on the line above"
         with
-        | :? JsonException as e -> Assert.Equal("Record field 'by' is a non-optional field.", e.Message)
+        | :? JsonException as e -> Assert.Equal("Record field 'by' in type 'B' cannot be null.", e.Message)
 
     type C =
         {


### PR DESCRIPTION
There should probably be check on `[<AllowNullLiteral>]`(?) for the given type on the off chance somebody actually _wants_ nulls in their F# record type.