### PR TITLE
Forbid nulls inside arrays, sets and tuples unless 'T isNullableFieldType

### DIFF
--- a/src/FSharp.SystemTextJson/All.fs
+++ b/src/FSharp.SystemTextJson/All.fs
@@ -13,7 +13,7 @@ type JsonFSharpConverter(fsOptions: JsonFSharpOptions) =
     static member internal CreateConverter(typeToConvert, options, fsOptions) =
         match TypeCache.getKind typeToConvert with
         | TypeCache.TypeKind.List ->
-            JsonListConverter.CreateConverter(typeToConvert)
+            JsonListConverter.CreateConverter(typeToConvert, fsOptions)
         | TypeCache.TypeKind.Set ->
             JsonSetConverter.CreateConverter(typeToConvert)
         | TypeCache.TypeKind.Map ->

--- a/src/FSharp.SystemTextJson/All.fs
+++ b/src/FSharp.SystemTextJson/All.fs
@@ -15,11 +15,11 @@ type JsonFSharpConverter(fsOptions: JsonFSharpOptions) =
         | TypeCache.TypeKind.List ->
             JsonListConverter.CreateConverter(typeToConvert, fsOptions)
         | TypeCache.TypeKind.Set ->
-            JsonSetConverter.CreateConverter(typeToConvert)
+            JsonSetConverter.CreateConverter(typeToConvert, fsOptions)
         | TypeCache.TypeKind.Map ->
             JsonMapConverter.CreateConverter(typeToConvert)
         | TypeCache.TypeKind.Tuple ->
-            JsonTupleConverter.CreateConverter(typeToConvert)
+            JsonTupleConverter.CreateConverter(typeToConvert, fsOptions)
         | TypeCache.TypeKind.Record ->
             JsonRecordConverter.CreateConverter(typeToConvert, options, fsOptions)
         | TypeCache.TypeKind.Union ->

--- a/src/FSharp.SystemTextJson/Collection.fs
+++ b/src/FSharp.SystemTextJson/Collection.fs
@@ -9,10 +9,11 @@ type JsonListConverter<'T>(fsOptions) =
     inherit JsonConverter<list<'T>>()
     let tType = typeof<'T>
     let tIsNullable = isNullableFieldType fsOptions tType
+    let needsNullChecking = not tIsNullable && not tType.IsValueType
 
     override _.Read(reader, _typeToConvert, options) =
         let array = JsonSerializer.Deserialize<'T[]>(&reader, options)
-        if not tIsNullable then
+        if needsNullChecking then
             for elem in array do
                 if isNull (box elem) then
                     let msg = sprintf "Unexpected null inside array. Expected only elements of type %s" tType.Name

--- a/tests/FSharp.SystemTextJson.Tests/Test.Collection.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Collection.fs
@@ -47,6 +47,14 @@ module NullsInsideList =
         | Error msg -> Assert.Equal("Unexpected null inside array. Expected only elements of type String", msg)
         | _ -> failwith "expected failure"
 
+    [<Fact>]
+    let ``allow nulls inside array if allowNullFields is true ``() =
+        let options = JsonSerializerOptions()
+        options.Converters.Add(JsonFSharpConverter(allowNullFields = true))
+        let ser = """["hello", null]"""
+        let actual = JsonSerializer.Deserialize<string list>(ser,options)
+        Assert.Equal<string list>(["hello"; null], actual)
+
 [<Property>]
 let ``serialize set of ints`` (s: Set<int>) =
     let expected = "[" + String.concat "," (Seq.map string s) + "]"

--- a/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
@@ -290,7 +290,7 @@ module Struct =
         options.Converters.Add(JsonFSharpConverter(allowNullFields = true))
         let actual = JsonSerializer.Deserialize("""{"bx":1,"by":null}""", options)
         Assert.Equal({bx=1;by=null}, actual)
-       
+
     [<Struct>]
     type S =
         {


### PR DESCRIPTION
~Work in progress.~

~Need to implement the same behaviour for Sets, and perhaps `JsonStringMapConverter`  and `JsonMapConverter`?~

~I need some feedback before implementing the same behaviour there though.~ (Done!)

------

Ready for merge if everything checks out and looks ok 😁 
