### PR TITLE
Support records with read only members

### DIFF
--- a/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
@@ -442,3 +442,15 @@ module Struct =
     let ``serialize with property case insensitive`` () =
         let actual = JsonSerializer.Serialize({CcFirst = 1; CcSecond = "a"}, propertyNameCaseInsensitiveOptions)
         Assert.Equal("""{"CcFirst":1,"CcSecond":"a"}""", actual)
+    
+    type RecordWithReadOnlyMember =
+        {
+            CcFirst: int
+            CcSecond: string
+        }
+        with member _.Member = "b"
+
+    [<Fact>]
+    let ``serialize record member fields`` () =
+        let actual = JsonSerializer.Serialize({CcFirst = 1; CcSecond = "a"}, propertyNameCaseInsensitiveOptions)
+        Assert.Equal("""{"CcFirst":1,"CcSecond":"a","Member":"b"}""", actual)


### PR DESCRIPTION
Currently record members are ignored during serialization. I'm not sure if that's something you want to support, but if so, I thought I could at least provide the failing test. I've already tried to implement it myself but couldn't find a way without rewriting quite a bit of code, so maybe you've a better idea how to fix this issue. 
My workaround is currently to simply use a custom converter for the specific types. 

Thanks.