### PR TITLE
Fixes unit field deserialization

### DIFF
--- a/src/FSharp.SystemTextJson/Helpers.fs
+++ b/src/FSharp.SystemTextJson/Helpers.fs
@@ -46,6 +46,7 @@ let rec isNullableFieldType (fsOptions: JsonFSharpOptions) (ty: Type) =
         && ty.IsGenericType
         && ty.GetGenericTypeDefinition() = typedefof<voption<_>>)
     || (isSkippableType ty && isNullableFieldType fsOptions (ty.GetGenericArguments().[0]))
+    || (ty = typeof<Unit>)
 
 let isSkippableFieldType (fsOptions: JsonFSharpOptions) (ty: Type) =
     isNullableFieldType fsOptions ty

--- a/src/FSharp.SystemTextJson/Tuple.fs
+++ b/src/FSharp.SystemTextJson/Tuple.fs
@@ -19,7 +19,8 @@ type JsonTupleConverter<'T>(fsOptions) =
         FSharpType.GetTupleElements(ty)
         |> Array.map (fun t ->
             let tIsNullable = isNullableFieldType fsOptions t
-            let needsNullChecking = not tIsNullable && not t.IsValueType
+            let tIsUnit = t = typeof<Unit>
+            let needsNullChecking = not tIsNullable && not t.IsValueType && not tIsUnit
             {
                 Type = t
                 NeedsNullChecking = needsNullChecking

--- a/src/FSharp.SystemTextJson/Tuple.fs
+++ b/src/FSharp.SystemTextJson/Tuple.fs
@@ -19,8 +19,7 @@ type JsonTupleConverter<'T>(fsOptions) =
         FSharpType.GetTupleElements(ty)
         |> Array.map (fun t ->
             let tIsNullable = isNullableFieldType fsOptions t
-            let tIsUnit = t = typeof<Unit>
-            let needsNullChecking = not tIsNullable && not t.IsValueType && not tIsUnit
+            let needsNullChecking = not tIsNullable && not t.IsValueType
             {
                 Type = t
                 NeedsNullChecking = needsNullChecking

--- a/tests/FSharp.SystemTextJson.Tests/Test.Collection.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Collection.fs
@@ -161,6 +161,14 @@ let ``deserialize 2-tuple`` ((a, b as t): int * string) =
     | _, Error msg -> failwithf "Unexpected deserialization error %s" msg
 
 [<Property>]
+let ``deserialize 2-tuple with unit`` ((a, b as t): int * unit) =
+    let ser = sprintf "[%i,%s]" a (JsonSerializer.Serialize b)
+    let result = tryblock (fun () -> JsonSerializer.Deserialize<int * unit>(ser, options))
+    match result with
+    | Ok actual -> Assert.Equal(t, actual)
+    | Error msg -> failwithf "Unexpected deserialization error %s" msg
+
+[<Property>]
 let ``serialize 2-tuple`` ((a, b as t): int * string) =
     let expected = sprintf "[%i,%s]" a (JsonSerializer.Serialize b)
     let actual = JsonSerializer.Serialize(t, options)

--- a/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
@@ -493,6 +493,23 @@ module NonStruct =
         let actual = JsonSerializer.Deserialize("""{"a":"Red","b":"Blue"}""", serializerOptions)
         Assert.Equal({| a = Red; b = Blue |}, actual)
 
+    type UnionWithUnitField =
+        | UWUF of int * unit
+
+    [<Fact>]
+    let ``serializes union with unit field`` () =
+        let options = JsonSerializerOptions(PropertyNamingPolicy = JsonNamingPolicy.CamelCase)
+        options.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.AdjacentTag))
+        let actual = JsonSerializer.Serialize(UWUF (42,()), options)
+        Assert.Equal("""{"Case":"UWUF","Fields":[42,null]}""", actual)
+
+    [<Fact>]
+    let ``deserializes union with unit field`` () =
+        let options = JsonSerializerOptions(PropertyNamingPolicy = JsonNamingPolicy.CamelCase)
+        options.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.AdjacentTag))
+        let actual = JsonSerializer.Deserialize("""{"Case":"UWUF","Fields":[42,null]}""", options)
+        Assert.Equal(UWUF (42,()), actual)
+
 module Struct =
 
     [<Struct; JsonFSharpConverter>]


### PR DESCRIPTION
I was getting the error: `Unexpected null inside tuple-array. Expected type Unit, but got null.` when deserializing a type like `int * unit`. This PR removes null-checking for `unit` types inside a tuple and adds a test.

## Use case
It's an odd thing to serialize, but I use `TenantId * RequestParameters` across all my [Bolero IRemoteService endpoints](https://fsbolero.io/docs/Remoting). In a couple of places, there are no `RequestParameters` so I use `TenantId * unit` here to maintain a consistent shape.
Without this PR, a `_ * unit` tuple serializes but does not deserialize.

**Edit:** A consistent shape is useful so I can write things like:
 ```
member inline this.Authorize<'req, 'resp when 'req : (member get_Item1 : unit -> TenantId)> (f : 'req -> Async<'resp>) : 'req -> Async<'resp> = ...
```