### PR TITLE
Fix #69: allow overriding converter options in attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.13
+
+* [#69](https://github.com/Tarmil/FSharp.SystemTextJson/issues/69): Allow overriding `JsonFSharpConverter` options with `JsonFSharpConverterAttribute` by passing `allowOverride = true` to `JsonFSharpConverter`.
+
 ## 0.12
 
 * [#56](https://github.com/Tarmil/FSharp.SystemTextJson/issues/56): Add `JsonUnionEncoding.UnwrapRecordCases`, which implies `JsonUnionEncoding.NamedFields` and encodes union cases containing a single record field as if the record's fields were the union's fields instead. For example:

--- a/src/FSharp.SystemTextJson/All.fs
+++ b/src/FSharp.SystemTextJson/All.fs
@@ -42,14 +42,16 @@ type JsonFSharpConverter(fsOptions: JsonFSharpOptions) =
             [<Optional; DefaultParameterValue(Default.UnionTagCaseInsensitive)>]
             unionTagCaseInsensitive: bool,
             [<Optional; DefaultParameterValue(Default.AllowNullFields)>]
-            allowNullFields: bool
+            allowNullFields: bool,
+            [<Optional; DefaultParameterValue(false)>]
+            allowOverride: bool
         ) =
-        JsonFSharpConverter(JsonFSharpOptions(unionEncoding, unionTagName, unionFieldsName, unionTagNamingPolicy, unionTagCaseInsensitive, allowNullFields))
+        JsonFSharpConverter(JsonFSharpOptions(unionEncoding, unionTagName, unionFieldsName, unionTagNamingPolicy, unionTagCaseInsensitive, allowNullFields, allowOverride))
 
 [<AttributeUsage(AttributeTargets.Class ||| AttributeTargets.Struct)>]
 type JsonFSharpConverterAttribute
     (
-        [<Optional; DefaultParameterValue(Default.UnionEncoding)>]
+        [<Optional; DefaultParameterValue(Default.UnionEncoding ||| JsonUnionEncoding.Inherit)>]
         unionEncoding: JsonUnionEncoding,
         [<Optional; DefaultParameterValue(Default.UnionTagName)>]
         unionTagName: JsonUnionTagName,
@@ -64,7 +66,10 @@ type JsonFSharpConverterAttribute
 
     let options = JsonSerializerOptions()
 
-    let fsOptions = JsonFSharpOptions(unionEncoding, unionTagName, unionFieldsName, Default.UnionTagNamingPolicy, unionTagCaseInsensitive, allowNullFields)
+    let fsOptions = JsonFSharpOptions(unionEncoding, unionTagName, unionFieldsName, Default.UnionTagNamingPolicy, unionTagCaseInsensitive, allowNullFields, false)
 
     override _.CreateConverter(typeToConvert) =
         JsonFSharpConverter.CreateConverter(typeToConvert, options, fsOptions)
+
+    interface IJsonFSharpConverterAttribute with
+        member this.Options = fsOptions

--- a/src/FSharp.SystemTextJson/Helpers.fs
+++ b/src/FSharp.SystemTextJson/Helpers.fs
@@ -51,3 +51,11 @@ let rec isNullableFieldType (fsOptions: JsonFSharpOptions) (ty: Type) =
 let isSkippableFieldType (fsOptions: JsonFSharpOptions) (ty: Type) =
     isNullableFieldType fsOptions ty
     || isSkippableType ty
+
+let overrideOptions (ty: Type) (defaultOptions: JsonFSharpOptions) =
+    if defaultOptions.AllowOverride then
+        match ty.GetCustomAttributes(typeof<IJsonFSharpConverterAttribute>, true) |> Array.tryHead with
+        | Some (:? IJsonFSharpConverterAttribute as attr) -> attr.Options
+        | _ -> defaultOptions
+    else
+        defaultOptions

--- a/src/FSharp.SystemTextJson/Options.fs
+++ b/src/FSharp.SystemTextJson/Options.fs
@@ -9,68 +9,81 @@ type JsonUnionEncoding =
     //// General base format
 
     /// Encode unions as a 2-valued object:
-    /// `unionTagName` (defaults to "Case") contains the union tag, and "Fields" contains the union fields.
+    /// `unionTagName` (defaults to "Case") contains the union tag,
+    /// and `unionFieldsName` (defaults to "Fields") contains the union fields.
     /// If the case doesn't have fields, "Fields": [] is omitted.
-    | AdjacentTag       = 0x00_01
+    /// This flag is included in Default.
+    | AdjacentTag               = 0x00_00_00_01
 
     /// Encode unions as a 1-valued object:
     /// The field name is the union tag, and the value is the union fields.
-    | ExternalTag       = 0x00_02
+    | ExternalTag               = 0x00_00_00_02
 
     /// Encode unions as a (n+1)-valued object or array (depending on NamedFields):
     /// the first value (named `unionTagName`, defaulting to "Case", if NamedFields is set)
     /// is the union tag, the rest are the union fields.
-    | InternalTag       = 0x00_04
+    | InternalTag               = 0x00_00_00_04
 
     /// Encode unions as a n-valued object:
     /// the union tag is not encoded, only the union fields are.
     /// Deserialization is only possible if the fields of all cases have different names.
-    | Untagged          = 0x01_08
+    | Untagged                  = 0x00_00_01_08
+
+
+
+    //// Inheritance
+
+    /// When set on an FSharpJsonConverterAttribute (true if no encoding is passed),
+    /// inherit the union encoding from the FSharpJsonConverter, if any.
+    /// When set on an FSharpJsonConverter object, this flag is ignored.
+    | Inherit                   = 0x80_00_00_00
 
 
     //// Additional options
 
     /// If unset, union fields are encoded as an array.
     /// If set, union fields are encoded as an object using their field names.
-    | NamedFields       = 0x01_00
+    | NamedFields               = 0x00_00_01_00
 
     /// If set, union cases that don't have fields are encoded as a bare string.
-    | UnwrapFieldlessTags = 0x02_00
+    | UnwrapFieldlessTags       = 0x00_00_02_00
 
     /// Obsolete: use UnwrapFieldlessTags instead.
     | [<Obsolete "Use UnwrapFieldlessTags">]
-      BareFieldlessTags = 0x02_00
+      BareFieldlessTags         = 0x00_00_02_00
 
     /// If set, `None` is represented as null,
     /// and `Some x`  is represented the same as `x`.
-    | UnwrapOption      = 0x04_00
+    /// This flag is included in Default.
+    | UnwrapOption              = 0x00_00_04_00
 
     /// Obsolete: use UnwrapOption instead.
     | [<Obsolete "Use UnwrapOption">]
-      SuccintOption     = 0x04_00
+      SuccintOption             = 0x00_00_04_00
 
     /// If set, single-case single-field unions are serialized as the single field's value.
-    | UnwrapSingleCaseUnions = 0x08_00
+    /// This flag is included in Default.
+    | UnwrapSingleCaseUnions    = 0x00_00_08_00
 
     /// Obsolete: use UnwrapSingleCaseUnions instead.
     | [<Obsolete "Use UnwrapSingleCaseUnions">]
-      EraseSingleCaseUnions = 0x08_00
+      EraseSingleCaseUnions     = 0x00_00_08_00
 
     /// If set, the field of a single-field union case is encoded as just the value
     /// rather than a single-value array or object.
-    | UnwrapSingleFieldCases = 0x10_00
+    | UnwrapSingleFieldCases    = 0x00_00_10_00
 
     /// Implicitly sets NamedFields. If set, when a union case has a single field which is a record,
     /// the fields of this record are encoded directly as fields of the object representing the union.
-    | UnwrapRecordCases = 0x21_00
+    | UnwrapRecordCases         = 0x00_00_21_00
 
 
     //// Specific formats
 
-    | Default           = 0x0C_01
-    | NewtonsoftLike    = 0x00_01
-    | ThothLike         = 0x02_04
-    | FSharpLuLike      = 0x16_02
+    | Default                   = 0x00_00_0C_01
+    | NewtonsoftLike            = 0x00_00_00_01
+    | ThothLike                 = 0x00_00_02_04
+    | FSharpLuLike              = 0x00_00_16_02
 
 type JsonUnionTagName = string
 type JsonUnionFieldsName = string
@@ -102,7 +115,9 @@ type JsonFSharpOptions
         [<Optional; DefaultParameterValue(Default.UnionTagCaseInsensitive)>]
         unionTagCaseInsensitive: bool,
         [<Optional; DefaultParameterValue(Default.AllowNullFields)>]
-        allowNullFields: bool
+        allowNullFields: bool,
+        [<Optional; DefaultParameterValue(false)>]
+        allowOverride: bool
     ) =
 
     member this.UnionEncoding = unionEncoding
@@ -116,3 +131,8 @@ type JsonFSharpOptions
     member this.UnionTagCaseInsensitive = unionTagCaseInsensitive
 
     member this.AllowNullFields = allowNullFields
+
+    member this.AllowOverride = allowOverride
+
+type IJsonFSharpConverterAttribute =
+    abstract Options: JsonFSharpOptions

--- a/src/FSharp.SystemTextJson/Record.fs
+++ b/src/FSharp.SystemTextJson/Record.fs
@@ -161,7 +161,8 @@ type JsonRecordConverter(fsOptions: JsonFSharpOptions) =
     static member internal CanConvert(typeToConvert) =
         TypeCache.isRecord typeToConvert
 
-    static member internal CreateConverter(typeToConvert, options: JsonSerializerOptions, fsOptions: JsonFSharpOptions) =
+    static member internal CreateConverter(typeToConvert: Type, options: JsonSerializerOptions, fsOptions: JsonFSharpOptions) =
+        let fsOptions = overrideOptions typeToConvert fsOptions
         typedefof<JsonRecordConverter<_>>
             .MakeGenericType([|typeToConvert|])
             .GetConstructor([|typeof<JsonSerializerOptions>; typeof<JsonFSharpOptions>|])

--- a/src/FSharp.SystemTextJson/Union.fs
+++ b/src/FSharp.SystemTextJson/Union.fs
@@ -501,6 +501,7 @@ type JsonUnionConverter(fsOptions: JsonFSharpOptions) =
         TypeCache.isUnion typeToConvert
 
     static member internal CreateConverter(typeToConvert: Type, options: JsonSerializerOptions, fsOptions: JsonFSharpOptions) =
+        let fsOptions = overrideOptions typeToConvert fsOptions
         if fsOptions.UnionEncoding.HasFlag JsonUnionEncoding.UnwrapOption
             && typeToConvert.IsGenericType
             && typeToConvert.GetGenericTypeDefinition() = optionTy then

--- a/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
@@ -229,6 +229,25 @@ module NonStruct =
         with
         | :? JsonException as e -> Assert.Equal("Missing field for record type Tests.Record+NonStruct+D: dx", e.Message)
 
+    [<JsonFSharpConverter(allowNullFields = false)>]
+    type Override =
+        {
+            x: string
+        }
+
+    [<Fact>]
+    let ``should not override allowNullFields in attribute if AllowOverride = false`` () =
+        let o = JsonSerializerOptions()
+        o.Converters.Add(JsonFSharpConverter(allowNullFields = true))
+        Assert.Equal({x=null}, JsonSerializer.Deserialize<Override>("""{"x":null}""", o))
+
+    [<Fact>]
+    let ``should override allowNullFields in attribute if AllowOverride = true`` () =
+        let o = JsonSerializerOptions()
+        o.Converters.Add(JsonFSharpConverter(allowNullFields = true, allowOverride = true))
+        Assert.Throws<JsonException>(fun () -> JsonSerializer.Deserialize<Override>("""{"x":null}""", o) |> ignore)
+        |> ignore
+
 module Struct =
 
     [<Struct; JsonFSharpConverter>]
@@ -442,3 +461,23 @@ module Struct =
     let ``serialize with property case insensitive`` () =
         let actual = JsonSerializer.Serialize({CcFirst = 1; CcSecond = "a"}, propertyNameCaseInsensitiveOptions)
         Assert.Equal("""{"CcFirst":1,"CcSecond":"a"}""", actual)
+
+    [<JsonFSharpConverter(allowNullFields = false)>]
+    [<Struct>]
+    type Override =
+        {
+            x: string
+        }
+
+    [<Fact>]
+    let ``should not override allowNullFields in attribute if AllowOverride = false`` () =
+        let o = JsonSerializerOptions()
+        o.Converters.Add(JsonFSharpConverter(allowNullFields = true))
+        Assert.Equal({x=null}, JsonSerializer.Deserialize<Override>("""{"x":null}""", o))
+
+    [<Fact>]
+    let ``should override allowNullFields in attribute if AllowOverride = true`` () =
+        let o = JsonSerializerOptions()
+        o.Converters.Add(JsonFSharpConverter(allowNullFields = true, allowOverride = true))
+        Assert.Throws<JsonException>(fun () -> JsonSerializer.Deserialize<Override>("""{"x":null}""", o) |> ignore)
+        |> ignore

--- a/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
@@ -586,6 +586,33 @@ module NonStruct =
             let actual = JsonSerializer.Deserialize("""{"v":42}""", untaggedOptions)
             Assert.Equal(V 42, actual)
 
+    [<JsonFSharpConverter(unionTagName = "tag", unionFieldsName = "val")>]
+    type Override =
+        | A of int * string
+
+    [<Fact>]
+    let ``should not override tag name in attribute if AllowOverride = false`` () =
+        let o = JsonSerializerOptions()
+        o.Converters.Add(JsonFSharpConverter())
+        Assert.Equal("""{"Case":"A","Fields":[123,"abc"]}""", JsonSerializer.Serialize(Override.A(123, "abc"), o))
+
+    [<Fact>]
+    let ``should override tag name in attribute if AllowOverride = true`` () =
+        let o = JsonSerializerOptions()
+        o.Converters.Add(JsonFSharpConverter(allowOverride = true))
+        Assert.Equal("""{"tag":"A","val":[123,"abc"]}""", JsonSerializer.Serialize(Override.A(123, "abc"), o))
+
+    [<JsonFSharpConverter(JsonUnionEncoding.InternalTag)>]
+    type Override2 =
+        | A of int * string
+
+    [<Fact>]
+    let ``should override JsonEncoding if specified`` () =
+        let o = JsonSerializerOptions()
+        o.Converters.Add(JsonFSharpConverter(allowOverride = true))
+        Assert.Equal("""["A",123,"abc"]""", JsonSerializer.Serialize(Override2.A(123, "abc"), o))
+
+
 module Struct =
 
     [<Struct; JsonFSharpConverter>]
@@ -1133,3 +1160,31 @@ module Struct =
             Assert.Equal(U { x = 1; y = 2. }, actual)
             let actual = JsonSerializer.Deserialize("""{"v":42}""", untaggedOptions)
             Assert.Equal(V 42, actual)
+
+    [<JsonFSharpConverter(unionTagName = "tag", unionFieldsName = "val")>]
+    [<Struct>]
+    type Override =
+        | A of int * string
+
+    [<Fact>]
+    let ``should not override tag name in attribute if AllowOverride = false`` () =
+        let o = JsonSerializerOptions()
+        o.Converters.Add(JsonFSharpConverter())
+        Assert.Equal("""{"Case":"A","Fields":[123,"abc"]}""", JsonSerializer.Serialize(Override.A(123, "abc"), o))
+
+    [<Fact>]
+    let ``should override tag name in attribute if AllowOverride = true`` () =
+        let o = JsonSerializerOptions()
+        o.Converters.Add(JsonFSharpConverter(allowOverride = true))
+        Assert.Equal("""{"tag":"A","val":[123,"abc"]}""", JsonSerializer.Serialize(Override.A(123, "abc"), o))
+
+    [<JsonFSharpConverter(JsonUnionEncoding.InternalTag)>]
+    [<Struct>]
+    type Override2 =
+        | A of int * string
+
+    [<Fact>]
+    let ``should override JsonEncoding if specified`` () =
+        let o = JsonSerializerOptions()
+        o.Converters.Add(JsonFSharpConverter(allowOverride = true))
+        Assert.Equal("""["A",123,"abc"]""", JsonSerializer.Serialize(Override2.A(123, "abc"), o))


### PR DESCRIPTION
Example:

```fsharp
[<JsonFSharpConverter(unionTagName = "tag")>]
type Foo = Foo of x: int * y: string

// Default behavior:
let options = JsonSerializerOptions()
options.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.InternalTag))
JsonSerializer.Serialize(Foo(1, "a")) // = {"Case":"Foo","x":1,"y":"a"]}

// With allowOverride:
let options = JsonSerializerOptions()
options.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.InternalTag, allowOverride = true))
JsonSerializer.Serialize(Foo(1, "a")) // = {"tag":"Foo","x":1,"y":"a"]}
```