### PR TITLE
Implemented ability to deserialize discriminated unions regardless of union tag position

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -93,7 +93,7 @@ Target.create "TestTrim" <| fun _ ->
 /// project(s) as part of the run.
 Target.create "Benchmark" (fun _ ->
     DotNet.exec (fun o -> { o with 
-                                WorkingDirectory = Paths.benchmarks } ) "run" "-c release --filter \"*\""
+                                WorkingDirectory = Paths.benchmarks } ) "run" "-c release --runtimes netcoreapp50 --filter \"*\""
     |> checkOk "Benchmarks"
 )
 

--- a/docs/Customizing.md
+++ b/docs/Customizing.md
@@ -406,6 +406,27 @@ type Location =
     // Instead of {"Item":{"lat":48.858,"long":2.295}}
     ```
 
+#### `AllowUnorderedTag`
+
+`JsonUnionEncoding.AllowUnorderedTag` is enabled by default.
+It takes effect during deserialization in AdjacentTag and InternalTag modes.
+When it is disabled, the name of the case must be the first field of the JSON object.
+When it is enabled, the name of the case may come later in the object, at the cost of a slight performance penalty if it does.
+
+For example, without `AllowUnorderedTag`, the following will fail to parse:
+
+```fsharp
+JsonSerializer.Deserialize("""{"Fields":[3.14],"Case":"WithOneArg"}""", options)
+// --> Error: Failed to find union case field for Example: expected Case
+```
+
+Whereas with `AllowUnorderedTag`, it will succeed:
+
+```fsharp
+JsonSerializer.Deserialize("""{"Fields":[3.14],"Case":"WithOneArg"}""", options)
+// --> WithOneArg 3.14
+```
+
 ### Combined flags
 
 `JsonUnionEncoding` also contains a few items that combine several of the above flags.
@@ -417,6 +438,7 @@ type Location =
     JsonUnionEncoding.AdjacentTag
     ||| JsonUnionEncoding.UnwrapOption
     ||| JsonUnionEncoding.UnwrapSingleCaseUnions
+    ||| JsonUnionEncoding.AllowUnorderedTag
     ```
 
     It is particularly useful if you want to use the default encoding with some additional options, for example:
@@ -430,6 +452,7 @@ type Location =
 
     ```fsharp
     JsonUnionEncoding.AdjacentTag
+    ||| JsonUnionEncoding.AllowUnorderedTag
     ```
 
 * `JsonUnionEncoding.ThothLike` causes similar behavior to the library [Thoth.Json](https://thoth-org.github.io/Thoth.Json/).
@@ -438,6 +461,7 @@ type Location =
     ```fsharp
     JsonUnionEncoding.InternalTag
     ||| JsonUnionEncoding.UnwrapFieldlessTags
+    ||| JsonUnionEncoding.AllowUnorderedTag
     ```
 
 * `JsonUnionEncoding.FSharpLuLike` causes similar behavior to the library [FSharpLu.Json](https://github.com/microsoft/fsharplu/wiki/FSharpLu.Json) in Compact mode.
@@ -448,6 +472,7 @@ type Location =
     ||| JsonUnionEncoding.UnwrapFieldlessTags
     ||| JsonUnionEncoding.UnwrapOption
     ||| JsonUnionEncoding.UnwrapSingleFieldCases
+    ||| JsonUnionEncoding.AllowUnorderedTag
     ```
 
 ## `unionTagName`

--- a/src/FSharp.SystemTextJson/Helpers.fs
+++ b/src/FSharp.SystemTextJson/Helpers.fs
@@ -19,8 +19,11 @@ let readExpecting expectedTokenType expectedLabel (reader: byref<Utf8JsonReader>
     if not (reader.Read()) || reader.TokenType <> expectedTokenType then
         fail expectedLabel &reader ty
 
+let inline readIsExpectingPropertyNamed (expectedPropertyName: string) (reader: byref<Utf8JsonReader>) ty =
+    (reader.Read()) && reader.TokenType = JsonTokenType.PropertyName && (reader.ValueTextEquals expectedPropertyName)
+
 let readExpectingPropertyNamed (expectedPropertyName: string) (reader: byref<Utf8JsonReader>) ty =
-    if not (reader.Read()) || reader.TokenType <> JsonTokenType.PropertyName || not (reader.ValueTextEquals expectedPropertyName) then
+    if not <| readIsExpectingPropertyNamed expectedPropertyName &reader ty then
         fail ("\"" + expectedPropertyName + "\"") &reader ty
 
 let isNullableUnion (ty: Type) =

--- a/src/FSharp.SystemTextJson/Options.fs
+++ b/src/FSharp.SystemTextJson/Options.fs
@@ -77,13 +77,17 @@ type JsonUnionEncoding =
     /// the fields of this record are encoded directly as fields of the object representing the union.
     | UnwrapRecordCases         = 0x00_00_21_00
 
+    /// In AdjacentTag and InternalTag mode, allow deserializing unions
+    /// where the tag is not the first field in the JSON object.
+    | AllowUnorderedTag         = 0x00_00_40_00
+
 
     //// Specific formats
 
-    | Default                   = 0x00_00_0C_01
-    | NewtonsoftLike            = 0x00_00_00_01
-    | ThothLike                 = 0x00_00_02_04
-    | FSharpLuLike              = 0x00_00_16_02
+    | Default                   = 0x00_00_4C_01 // AdjacentTag ||| UnwrapOption ||| UnwrapSingleCaseUnions ||| AllowUnorderedTag
+    | NewtonsoftLike            = 0x00_00_40_01 // AdjacentTag ||| AllowUnorderedTag
+    | ThothLike                 = 0x00_00_42_04 // InternalTag ||| BareFieldlessTags ||| AllowUnorderedTag
+    | FSharpLuLike              = 0x00_00_56_02 // ExternalTag ||| BareFieldlessTags ||| UnwrapOption ||| UnwrapSingleFieldCases ||| AllowUnorderedTag
 
 type JsonUnionTagName = string
 type JsonUnionFieldsName = string

--- a/src/FSharp.SystemTextJson/Union.fs
+++ b/src/FSharp.SystemTextJson/Union.fs
@@ -316,7 +316,7 @@ type JsonUnionConverter<'T>
         match document.RootElement.TryGetProperty fsOptions.UnionTagName with
         | true, element -> getCaseByTagString (element.GetString())
         | false, _ ->
-            sprintf "Failed to find union case field for %s: expected %s" ty.FullName fsOptions.UnionFieldsName
+            sprintf "Failed to find union case field for %s: expected %s" ty.FullName fsOptions.UnionTagName
             |> JsonException
             |> raise
 
@@ -329,7 +329,7 @@ type JsonUnionConverter<'T>
         elif fsOptions.UnionEncoding.HasFlag JsonUnionEncoding.AllowUnorderedTag then
             struct (getCaseFromDocument reader, true)
         else
-            sprintf "Failed to find union case field for %s: expected %s" ty.FullName fsOptions.UnionFieldsName
+            sprintf "Failed to find union case field for %s: expected %s" ty.FullName fsOptions.UnionTagName
             |> JsonException
             |> raise
 

--- a/src/FSharp.SystemTextJson/Union.fs
+++ b/src/FSharp.SystemTextJson/Union.fs
@@ -326,8 +326,12 @@ type JsonUnionConverter<'T>
             readExpectingPropertyNamed fsOptions.UnionTagName &reader ty
             readExpecting JsonTokenType.String "case name" &reader ty
             struct (getCaseByTagReader &reader, false)
-        else
+        elif fsOptions.UnionEncoding.HasFlag JsonUnionEncoding.AllowUnorderedTag then
             struct (getCaseFromDocument reader, true)
+        else
+            sprintf "Failed to find union case field for %s: expected %s" ty.FullName fsOptions.UnionFieldsName
+            |> JsonException
+            |> raise
 
     let readAdjacentTag (reader: byref<Utf8JsonReader>) (options: JsonSerializerOptions) =
         expectAlreadyRead JsonTokenType.StartObject "object" &reader ty

--- a/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
@@ -17,6 +17,7 @@ module NonStruct =
         Assert.Equal(Aa, JsonSerializer.Deserialize """{"Case":"Aa"}""")
         Assert.Equal(Ab 32, JsonSerializer.Deserialize """{"Case":"Ab","Fields":[32]}""")
         Assert.Equal(Ac("test", true), JsonSerializer.Deserialize """{"Case":"Ac","Fields":["test",true]}""")
+        Assert.Equal(Ac("test", true), JsonSerializer.Deserialize """{"Fields":["test",true],"Case":"Ac"}""")
 
     [<Fact>]
     let ``serialize via explicit converter`` () =
@@ -37,6 +38,7 @@ module NonStruct =
         Assert.Equal(Ba, JsonSerializer.Deserialize("""{"Case":"Ba"}""", options))
         Assert.Equal(Bb 32, JsonSerializer.Deserialize("""{"Case":"Bb","Fields":[32]}""", options))
         Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"Case":"Bc","Fields":["test",true]}""", options))
+        Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"Fields":["test",true],"Case":"Bc"}""", options))
 
     [<Fact>]
     let ``serialize via options`` () =
@@ -67,6 +69,7 @@ module NonStruct =
         Assert.Equal(Ba, JsonSerializer.Deserialize("""{"Case":"ba"}""", tagPolicyOptions))
         Assert.Equal(Bb 32, JsonSerializer.Deserialize("""{"Case":"bb","Fields":[32]}""", tagPolicyOptions))
         Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"Case":"bc","Fields":["test",true]}""", tagPolicyOptions))
+        Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"Fields":["test",true],"Case":"bc"}""", tagPolicyOptions))
 
     [<Fact>]
     let ``serialize AdjacentTag with tag policy`` () =
@@ -82,6 +85,7 @@ module NonStruct =
         Assert.Equal(Ba, JsonSerializer.Deserialize("""{"Case":"bA"}""", tagCaseInsensitiveOptions))
         Assert.Equal(Bb 32, JsonSerializer.Deserialize("""{"Case":"bB", "Fields":[32]}""", tagCaseInsensitiveOptions))
         Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"Case":"bC", "Fields":["test",true]}""", tagCaseInsensitiveOptions))
+        Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"Fields":["test",true],"Case":"bC"}""", tagCaseInsensitiveOptions))
 
     [<Fact>]
     let ``serialize AdjacentTag with case insensitive tag`` () =
@@ -98,6 +102,7 @@ module NonStruct =
     let ``deserialize UseNull`` () =
         Assert.Equal(Ca, JsonSerializer.Deserialize("""null""", options))
         Assert.Equal(Cb 32, JsonSerializer.Deserialize("""{"Case":"Cb","Fields":[32]}""", options))
+        Assert.Equal(Cb 32, JsonSerializer.Deserialize("""{"Fields":[32],"Case":"Cb"}""", options))
 
     [<Fact>]
     let ``serialize UseNull`` () =
@@ -187,6 +192,7 @@ module NonStruct =
         Assert.Equal(Ba, JsonSerializer.Deserialize("""{"Case":"Ba"}""", adjacentTagNamedFieldsOptions))
         Assert.Equal(Bb 32, JsonSerializer.Deserialize("""{"Case":"Bb","Fields":{"Item":32}}""", adjacentTagNamedFieldsOptions))
         Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"Case":"Bc","Fields":{"x":"test","Item2":true}}""", adjacentTagNamedFieldsOptions))
+        Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"Fields":{"x":"test","Item2":true},"Case":"Bc"}""", adjacentTagNamedFieldsOptions))
 
     [<Fact>]
     let ``serialize AdjacentTag NamedFields`` () =
@@ -202,6 +208,7 @@ module NonStruct =
         Assert.Equal(Ba, JsonSerializer.Deserialize("""{"Case":"ba"}""", adjacentTagNamedFieldsTagPolicyOptions))
         Assert.Equal(Bb 32, JsonSerializer.Deserialize("""{"Case":"bb","Fields":{"Item":32}}""", adjacentTagNamedFieldsTagPolicyOptions))
         Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"Case":"bc","Fields":{"x":"test","Item2":true}}""", adjacentTagNamedFieldsTagPolicyOptions))
+        Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"Fields":{"x":"test","Item2":true},"Case":"bc"}""", adjacentTagNamedFieldsTagPolicyOptions))
 
     [<Fact>]
     let ``serialize AdjacentTag NamedFields with tag policy`` () =
@@ -247,6 +254,7 @@ module NonStruct =
         Assert.Equal(Ba, JsonSerializer.Deserialize("""{"Case":"Ba"}""", internalTagNamedFieldsOptions))
         Assert.Equal(Bb 32, JsonSerializer.Deserialize("""{"Case":"Bb","Item":32}""", internalTagNamedFieldsOptions))
         Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"Case":"Bc","x":"test","Item2":true}""", internalTagNamedFieldsOptions))
+        Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"x":"test","Item2":true,"Case":"Bc"}""", internalTagNamedFieldsOptions))
 
     [<Fact>]
     let ``serialize InternalTag NamedFields`` () =
@@ -262,6 +270,7 @@ module NonStruct =
         Assert.Equal(S(1,Skip,Skip,Skip), JsonSerializer.Deserialize("""{"Case":"S","a":1}""", internalTagNamedFieldsOptions))
         Assert.Equal(S(1,Include 2,Include None,Include ValueNone), JsonSerializer.Deserialize("""{"Case":"S","a":1,"b":2,"c":null,"d":null}""", internalTagNamedFieldsOptions))
         Assert.Equal(S(1,Include 2,Include(Some 3),Include(ValueSome 4)), JsonSerializer.Deserialize("""{"Case":"S","a":1,"b":2,"c":3,"d":4}""", internalTagNamedFieldsOptions))
+        Assert.Equal(S(1,Include 2,Include(Some 3),Include(ValueSome 4)), JsonSerializer.Deserialize("""{"a":1,"b":2,"Case":"S","c":3,"d":4}""", internalTagNamedFieldsOptions))
 
     [<Fact>]
     let ``serialize InternalTag NamedFields with Skippable fields`` () =
@@ -277,6 +286,7 @@ module NonStruct =
         Assert.Equal(Ba, JsonSerializer.Deserialize("""{"Case":"ba"}""", internalTagNamedFieldsTagPolicyOptions))
         Assert.Equal(Bb 32, JsonSerializer.Deserialize("""{"Case":"bb","Item":32}""", internalTagNamedFieldsTagPolicyOptions))
         Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"Case":"bc","x":"test","Item2":true}""", internalTagNamedFieldsTagPolicyOptions))
+        Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"x":"test","Case":"bc","Item2":true}""", internalTagNamedFieldsTagPolicyOptions))
 
     [<Fact>]
     let ``serialize InternalTag NamedFields with tag policy`` () =
@@ -292,6 +302,7 @@ module NonStruct =
         Assert.Equal(Ba, JsonSerializer.Deserialize("""{"type":"Ba"}""", internalTagNamedFieldsConfiguredTagOptions))
         Assert.Equal(Bb 32, JsonSerializer.Deserialize("""{"type":"Bb","Item":32}""", internalTagNamedFieldsConfiguredTagOptions))
         Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"type":"Bc","x":"test","Item2":true}""", internalTagNamedFieldsConfiguredTagOptions))
+        Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"x":"test","type":"Bc","Item2":true}""", internalTagNamedFieldsConfiguredTagOptions))
 
     [<Fact>]
     let ``serialize InternalTag NamedFields alternative Tag`` () =
@@ -307,6 +318,7 @@ module NonStruct =
         Assert.Equal(Ba, JsonSerializer.Deserialize("""{"type":"Ba"}""", adjacentTagNamedFieldsConfiguredFieldsOptions))
         Assert.Equal(Bb 32, JsonSerializer.Deserialize("""{"type":"Bb","args":[32]}""", adjacentTagNamedFieldsConfiguredFieldsOptions))
         Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"type":"Bc","args":["test",true]}""", adjacentTagNamedFieldsConfiguredFieldsOptions))
+        Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"args":["test",true],"type":"Bc"}""", adjacentTagNamedFieldsConfiguredFieldsOptions))
 
     [<Fact>]
     let ``serialize AdjacentTag NamedFields alternative Fields`` () =
@@ -650,6 +662,7 @@ module Struct =
         Assert.Equal(Aa, JsonSerializer.Deserialize """{"Case":"Aa"}""")
         Assert.Equal(Ab 32, JsonSerializer.Deserialize """{"Case":"Ab","Fields":[32]}""")
         Assert.Equal(Ac("test", true), JsonSerializer.Deserialize """{"Case":"Ac","Fields":["test",true]}""")
+        Assert.Equal(Ac("test", true), JsonSerializer.Deserialize """{"Fields":["test",true],"Case":"Ac"}""")
 
     [<Fact>]
     let ``serialize via explicit converter`` () =
@@ -671,6 +684,7 @@ module Struct =
         Assert.Equal(Ba, JsonSerializer.Deserialize("""{"Case":"Ba"}""", options))
         Assert.Equal(Bb 32, JsonSerializer.Deserialize("""{"Case":"Bb","Fields":[32]}""", options))
         Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"Case":"Bc","Fields":["test",true]}""", options))
+        Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"Fields":["test",true],"Case":"Bc"}""", options))
 
     [<Fact>]
     let ``serialize via options`` () =
@@ -714,6 +728,7 @@ module Struct =
         Assert.Equal(Ba, JsonSerializer.Deserialize("""{"Case":"ba"}""", tagPolicyOptions))
         Assert.Equal(Bb 32, JsonSerializer.Deserialize("""{"Case":"bb","Fields":[32]}""", tagPolicyOptions))
         Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"Case":"bc","Fields":["test",true]}""", tagPolicyOptions))
+        Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"Fields":["test",true],"Case":"bc"}""", tagPolicyOptions))
 
     [<Fact>]
     let ``serialize AdjacentTag with tag policy`` () =
@@ -729,6 +744,7 @@ module Struct =
         Assert.Equal(Ba, JsonSerializer.Deserialize("""{"Case":"bA"}""", tagCaseInsensitiveOptions))
         Assert.Equal(Bb 32, JsonSerializer.Deserialize("""{"Case":"bB", "Fields":[32]}""", tagCaseInsensitiveOptions))
         Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"Case":"bC", "Fields":["test",true]}""", tagCaseInsensitiveOptions))
+        Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"Fields":["test",true], "Case":"bC"}""", tagCaseInsensitiveOptions))
 
     [<Fact>]
     let ``serialize AdjacentTag with case insensitive tag`` () =
@@ -819,6 +835,7 @@ module Struct =
         Assert.Equal(Ba, JsonSerializer.Deserialize("""{"Case":"Ba"}""", adjacentTagNamedFieldsOptions))
         Assert.Equal(Bb 32, JsonSerializer.Deserialize("""{"Case":"Bb","Fields":{"Item":32}}""", adjacentTagNamedFieldsOptions))
         Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"Case":"Bc","Fields":{"x":"test","Item2":true}}""", adjacentTagNamedFieldsOptions))
+        Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"Fields":{"x":"test","Item2":true},"Case":"Bc"}""", adjacentTagNamedFieldsOptions))
 
     [<Fact>]
     let ``serialize AdjacentTag NamedFields`` () =
@@ -834,6 +851,7 @@ module Struct =
         Assert.Equal(Ba, JsonSerializer.Deserialize("""{"Case":"ba"}""", adjacentTagNamedFieldsTagPolicyOptions))
         Assert.Equal(Bb 32, JsonSerializer.Deserialize("""{"Case":"bb","Fields":{"Item":32}}""", adjacentTagNamedFieldsTagPolicyOptions))
         Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"Case":"bc","Fields":{"x":"test","Item2":true}}""", adjacentTagNamedFieldsTagPolicyOptions))
+        Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"Fields":{"x":"test","Item2":true},"Case":"bc"}""", adjacentTagNamedFieldsTagPolicyOptions))
 
     [<Fact>]
     let ``serialize AdjacentTag NamedFields with tag policy`` () =
@@ -879,6 +897,7 @@ module Struct =
         Assert.Equal(Ba, JsonSerializer.Deserialize("""{"Case":"Ba"}""", internalTagNamedFieldsOptions))
         Assert.Equal(Bb 32, JsonSerializer.Deserialize("""{"Case":"Bb","Item":32}""", internalTagNamedFieldsOptions))
         Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"Case":"Bc","x":"test","Item2":true}""", internalTagNamedFieldsOptions))
+        Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"x":"test","Case":"Bc","Item2":true}""", internalTagNamedFieldsOptions))
 
     [<Fact>]
     let ``serialize InternalTag NamedFields`` () =
@@ -895,6 +914,7 @@ module Struct =
         Assert.Equal(S(1,Skip,Skip,Skip), JsonSerializer.Deserialize("""{"Case":"S","a":1}""", internalTagNamedFieldsOptions))
         Assert.Equal(S(1,Include 2,Include None,Include ValueNone), JsonSerializer.Deserialize("""{"Case":"S","a":1,"b":2,"c":null,"d":null}""", internalTagNamedFieldsOptions))
         Assert.Equal(S(1,Include 2,Include(Some 3),Include(ValueSome 4)), JsonSerializer.Deserialize("""{"Case":"S","a":1,"b":2,"c":3,"d":4}""", internalTagNamedFieldsOptions))
+        Assert.Equal(S(1,Include 2,Include(Some 3),Include(ValueSome 4)), JsonSerializer.Deserialize("""{"a":1,"b":2,"Case":"S","c":3,"d":4}""", internalTagNamedFieldsOptions))
 
     [<Fact>]
     let ``serialize InternalTag NamedFields with Skippable fields`` () =
@@ -910,6 +930,7 @@ module Struct =
         Assert.Equal(Ba, JsonSerializer.Deserialize("""{"Case":"ba"}""", internalTagNamedFieldsTagPolicyOptions))
         Assert.Equal(Bb 32, JsonSerializer.Deserialize("""{"Case":"bb","Item":32}""", internalTagNamedFieldsTagPolicyOptions))
         Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"Case":"bc","x":"test","Item2":true}""", internalTagNamedFieldsTagPolicyOptions))
+        Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"x":"test","Item2":true,"Case":"bc"}""", internalTagNamedFieldsTagPolicyOptions))
 
     [<Fact>]
     let ``serialize InternalTag NamedFields with tag policy`` () =
@@ -925,6 +946,7 @@ module Struct =
         Assert.Equal(Ba, JsonSerializer.Deserialize("""{"type":"Ba"}""", internalTagNamedFieldsConfiguredTagOptions))
         Assert.Equal(Bb 32, JsonSerializer.Deserialize("""{"type":"Bb","Item":32}""", internalTagNamedFieldsConfiguredTagOptions))
         Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"type":"Bc","x":"test","Item2":true}""", internalTagNamedFieldsConfiguredTagOptions))
+        Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"x":"test","type":"Bc","Item2":true}""", internalTagNamedFieldsConfiguredTagOptions))
 
     [<Fact>]
     let ``serialize InternalTag NamedFields alternative Tag`` () =
@@ -940,6 +962,7 @@ module Struct =
         Assert.Equal(Ba, JsonSerializer.Deserialize("""{"type":"Ba"}""", adjacentTagConfiguredFieldsOptions))
         Assert.Equal(Bb 32, JsonSerializer.Deserialize("""{"type":"Bb","args":[32]}""", adjacentTagConfiguredFieldsOptions))
         Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"type":"Bc","args":["test",true]}""", adjacentTagConfiguredFieldsOptions))
+        Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"args":["test",true],"type":"Bc"}""", adjacentTagConfiguredFieldsOptions))
 
     [<Fact>]
     let ``serialize AdjacentTag NamedFields alternative Fields`` () =
@@ -955,6 +978,7 @@ module Struct =
         Assert.Equal(Ba, JsonSerializer.Deserialize("""{"Case":"Ba"}""", unwrapSingleFieldCasesOptions))
         Assert.Equal(Bb 32, JsonSerializer.Deserialize("""{"Case":"Bb","Fields":32}""", unwrapSingleFieldCasesOptions))
         Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"Case":"Bc","Fields":["test",true]}""", unwrapSingleFieldCasesOptions))
+        Assert.Equal(Bc("test", true), JsonSerializer.Deserialize("""{"Fields":["test",true],"Case":"Bc"}""", unwrapSingleFieldCasesOptions))
 
     [<Fact>]
     let ``serialize unwrapped single-field cases`` () =

--- a/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
@@ -185,7 +185,7 @@ module NonStruct =
         Assert.Equal("""{"x":"test","Item2":true}""", JsonSerializer.Serialize(Bc("test", true), untaggedOptions))
 
     let adjacentTagNamedFieldsOptions = JsonSerializerOptions()
-    adjacentTagNamedFieldsOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.AdjacentTag ||| JsonUnionEncoding.NamedFields))
+    adjacentTagNamedFieldsOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.AdjacentTag ||| JsonUnionEncoding.NamedFields ||| JsonUnionEncoding.AllowUnorderedTag))
 
     [<Fact>]
     let ``deserialize AdjacentTag NamedFields`` () =
@@ -201,7 +201,7 @@ module NonStruct =
         Assert.Equal("""{"Case":"Bc","Fields":{"x":"test","Item2":true}}""", JsonSerializer.Serialize(Bc("test", true), adjacentTagNamedFieldsOptions))
 
     let adjacentTagNamedFieldsTagPolicyOptions = JsonSerializerOptions()
-    adjacentTagNamedFieldsTagPolicyOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.AdjacentTag ||| JsonUnionEncoding.NamedFields, unionTagNamingPolicy = JsonNamingPolicy.CamelCase))
+    adjacentTagNamedFieldsTagPolicyOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.AdjacentTag ||| JsonUnionEncoding.NamedFields ||| JsonUnionEncoding.AllowUnorderedTag, unionTagNamingPolicy = JsonNamingPolicy.CamelCase))
 
     [<Fact>]
     let ``deserialize AdjacentTag NamedFields with tag policy`` () =
@@ -279,7 +279,7 @@ module NonStruct =
         Assert.Equal("""{"Case":"S","a":1,"b":2,"c":3,"d":4}""", JsonSerializer.Serialize(S(1,Include 2,Include(Some 3),Include(ValueSome 4)), internalTagNamedFieldsOptions))
 
     let internalTagNamedFieldsTagPolicyOptions = JsonSerializerOptions()
-    internalTagNamedFieldsTagPolicyOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.InternalTag ||| JsonUnionEncoding.NamedFields, unionTagNamingPolicy = JsonNamingPolicy.CamelCase))
+    internalTagNamedFieldsTagPolicyOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.InternalTag ||| JsonUnionEncoding.NamedFields ||| JsonUnionEncoding.AllowUnorderedTag, unionTagNamingPolicy = JsonNamingPolicy.CamelCase))
 
     [<Fact>]
     let ``deserialize InternalTag NamedFields with tag policy`` () =
@@ -295,7 +295,7 @@ module NonStruct =
         Assert.Equal("""{"Case":"bc","x":"test","Item2":true}""", JsonSerializer.Serialize(Bc("test", true), internalTagNamedFieldsTagPolicyOptions))
 
     let internalTagNamedFieldsConfiguredTagOptions = JsonSerializerOptions()
-    internalTagNamedFieldsConfiguredTagOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.InternalTag ||| JsonUnionEncoding.NamedFields, "type"))
+    internalTagNamedFieldsConfiguredTagOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.InternalTag ||| JsonUnionEncoding.NamedFields ||| JsonUnionEncoding.AllowUnorderedTag, "type"))
 
     [<Fact>]
     let ``deserialize InternalTag NamedFields alternative Tag`` () =
@@ -311,7 +311,7 @@ module NonStruct =
         Assert.Equal("""{"type":"Bc","x":"test","Item2":true}""", JsonSerializer.Serialize(Bc("test", true), internalTagNamedFieldsConfiguredTagOptions))
 
     let adjacentTagNamedFieldsConfiguredFieldsOptions = JsonSerializerOptions()
-    adjacentTagNamedFieldsConfiguredFieldsOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.AdjacentTag, "type", "args"))
+    adjacentTagNamedFieldsConfiguredFieldsOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.AdjacentTag ||| JsonUnionEncoding.AllowUnorderedTag, "type", "args"))
 
     [<Fact>]
     let ``deserialize AdjacentTag NamedFields alternative Fields`` () =
@@ -828,7 +828,7 @@ module Struct =
         Assert.Equal("""{"x":"test","Item2":true}""", JsonSerializer.Serialize(Bc("test", true), untaggedOptions))
 
     let adjacentTagNamedFieldsOptions = JsonSerializerOptions()
-    adjacentTagNamedFieldsOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.AdjacentTag ||| JsonUnionEncoding.NamedFields))
+    adjacentTagNamedFieldsOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.AdjacentTag ||| JsonUnionEncoding.NamedFields ||| JsonUnionEncoding.AllowUnorderedTag))
 
     [<Fact>]
     let ``deserialize AdjacentTag NamedFields`` () =
@@ -844,7 +844,7 @@ module Struct =
         Assert.Equal("""{"Case":"Bc","Fields":{"x":"test","Item2":true}}""", JsonSerializer.Serialize(Bc("test", true), adjacentTagNamedFieldsOptions))
 
     let adjacentTagNamedFieldsTagPolicyOptions = JsonSerializerOptions()
-    adjacentTagNamedFieldsTagPolicyOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.AdjacentTag ||| JsonUnionEncoding.NamedFields, unionTagNamingPolicy = JsonNamingPolicy.CamelCase))
+    adjacentTagNamedFieldsTagPolicyOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.AdjacentTag ||| JsonUnionEncoding.NamedFields ||| JsonUnionEncoding.AllowUnorderedTag, unionTagNamingPolicy = JsonNamingPolicy.CamelCase))
 
     [<Fact>]
     let ``deserialize AdjacentTag NamedFields with tag policy`` () =
@@ -923,7 +923,7 @@ module Struct =
         Assert.Equal("""{"Case":"S","a":1,"b":2,"c":3,"d":4}""", JsonSerializer.Serialize(S(1,Include 2,Include(Some 3),Include(ValueSome 4)), internalTagNamedFieldsOptions))
 
     let internalTagNamedFieldsTagPolicyOptions = JsonSerializerOptions()
-    internalTagNamedFieldsTagPolicyOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.InternalTag ||| JsonUnionEncoding.NamedFields, unionTagNamingPolicy = JsonNamingPolicy.CamelCase))
+    internalTagNamedFieldsTagPolicyOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.InternalTag ||| JsonUnionEncoding.NamedFields ||| JsonUnionEncoding.AllowUnorderedTag, unionTagNamingPolicy = JsonNamingPolicy.CamelCase))
 
     [<Fact>]
     let ``deserialize InternalTag NamedFields with tag policy`` () =
@@ -939,7 +939,7 @@ module Struct =
         Assert.Equal("""{"Case":"bc","x":"test","Item2":true}""", JsonSerializer.Serialize(Bc("test", true), internalTagNamedFieldsTagPolicyOptions))
 
     let internalTagNamedFieldsConfiguredTagOptions = JsonSerializerOptions()
-    internalTagNamedFieldsConfiguredTagOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.InternalTag ||| JsonUnionEncoding.NamedFields, "type"))
+    internalTagNamedFieldsConfiguredTagOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.InternalTag ||| JsonUnionEncoding.NamedFields ||| JsonUnionEncoding.AllowUnorderedTag, "type"))
 
     [<Fact>]
     let ``deserialize InternalTag NamedFields alternative Tag`` () =
@@ -955,7 +955,7 @@ module Struct =
         Assert.Equal("""{"type":"Bc","x":"test","Item2":true}""", JsonSerializer.Serialize(Bc("test", true), internalTagNamedFieldsConfiguredTagOptions))
 
     let adjacentTagConfiguredFieldsOptions = JsonSerializerOptions()
-    adjacentTagConfiguredFieldsOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.AdjacentTag, "type", "args"))
+    adjacentTagConfiguredFieldsOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.AdjacentTag ||| JsonUnionEncoding.AllowUnorderedTag, "type", "args"))
 
     [<Fact>]
     let ``deserialize AdjacentTag NamedFields alternative Fields`` () =


### PR DESCRIPTION
I create a snapshot of a reader (a copy of structure) and parse it into a `JsonDocument` (which is a lazy operation) and do a union case lookup.
I have not added new tests but played with modification of existing (not committed) so add tests as appropriate.

Fixes #93 