### PR TITLE
Add .xml with documentation comments to nupkg

### DIFF
--- a/src/FSharp.SystemTextJson/FSharp.SystemTextJson.fsproj
+++ b/src/FSharp.SystemTextJson/FSharp.SystemTextJson.fsproj
@@ -8,6 +8,7 @@
     <PackageProjectUrl>https://github.com/tarmil/FSharp.SystemTextJson</PackageProjectUrl>
     <RepositoryUrl>https://github.com/tarmil/FSharp.SystemTextJson.git</RepositoryUrl>
     <Tags>F#;FSharp;Json</Tags>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- SourceLink settings -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>


### PR DESCRIPTION
Adds `GenerateDocumentationFile` Property to fsproj file. F# compiler
does not generate the .xml file by default, so
FSharp.SystemTextJson nuget packages didn't show any documentation in autocompletion.

Before:
![image](https://user-images.githubusercontent.com/7894687/172169890-88565327-7a29-451a-8ea5-fb00839a183d.png)


After:
![image](https://user-images.githubusercontent.com/7894687/172169965-f9928fd4-8bc1-4a7c-8ac8-a20761c7bc9c.png)
