### PR TITLE
[#108] Add UnionFieldNamesFromTypes

### DIFF
--- a/src/FSharp.SystemTextJson/All.fs
+++ b/src/FSharp.SystemTextJson/All.fs
@@ -45,6 +45,8 @@ type JsonFSharpConverter
             unionFieldsName: JsonUnionFieldsName,
             [<Optional; DefaultParameterValue(Default.UnionTagNamingPolicy)>]
             unionTagNamingPolicy: JsonNamingPolicy,
+            [<Optional; DefaultParameterValue(Default.UnionTagNamingPolicy)>]
+            unionFieldNamingPolicy: JsonNamingPolicy,
             [<Optional; DefaultParameterValue(Default.UnionTagCaseInsensitive)>]
             unionTagCaseInsensitive: bool,
             [<Optional; DefaultParameterValue(Default.AllowNullFields)>]
@@ -54,7 +56,7 @@ type JsonFSharpConverter
             [<Optional>]
             overrides: IDictionary<Type, JsonFSharpOptions>
         ) =
-        JsonFSharpConverter(JsonFSharpOptions(unionEncoding, unionTagName, unionFieldsName, unionTagNamingPolicy, unionTagCaseInsensitive, allowNullFields, allowOverride), overrides)
+        JsonFSharpConverter(JsonFSharpOptions(unionEncoding, unionTagName, unionFieldsName, unionTagNamingPolicy, unionFieldNamingPolicy, unionTagCaseInsensitive, allowNullFields, allowOverride), overrides)
 
 [<AttributeUsage(AttributeTargets.Class ||| AttributeTargets.Struct)>]
 type JsonFSharpConverterAttribute
@@ -74,7 +76,7 @@ type JsonFSharpConverterAttribute
 
     let options = JsonSerializerOptions()
 
-    let fsOptions = JsonFSharpOptions(unionEncoding, unionTagName, unionFieldsName, Default.UnionTagNamingPolicy, unionTagCaseInsensitive, allowNullFields, false)
+    let fsOptions = JsonFSharpOptions(unionEncoding, unionTagName, unionFieldsName, Default.UnionTagNamingPolicy, Default.UnionFieldNamingPolicy, unionTagCaseInsensitive, allowNullFields, false)
 
     override _.CreateConverter(typeToConvert) =
         JsonFSharpConverter.CreateConverter(typeToConvert, options, fsOptions, null)

--- a/src/FSharp.SystemTextJson/Options.fs
+++ b/src/FSharp.SystemTextJson/Options.fs
@@ -104,6 +104,8 @@ module internal Default =
     let [<Literal>] UnionFieldsName = "Fields"
 
     let [<Literal>] UnionTagNamingPolicy = null : JsonNamingPolicy
+    
+    let [<Literal>] UnionFieldNamingPolicy = null : JsonNamingPolicy
 
     let [<Literal>] UnionTagCaseInsensitive = false
 
@@ -119,6 +121,8 @@ type JsonFSharpOptions
         unionFieldsName: JsonUnionFieldsName,
         [<Optional; DefaultParameterValue(Default.UnionTagNamingPolicy)>]
         unionTagNamingPolicy: JsonNamingPolicy,
+        [<Optional; DefaultParameterValue(Default.UnionTagNamingPolicy)>]
+        unionFieldNamingPolicy: JsonNamingPolicy,
         [<Optional; DefaultParameterValue(Default.UnionTagCaseInsensitive)>]
         unionTagCaseInsensitive: bool,
         [<Optional; DefaultParameterValue(Default.AllowNullFields)>]
@@ -135,6 +139,8 @@ type JsonFSharpOptions
 
     member this.UnionTagNamingPolicy = unionTagNamingPolicy
 
+    member this.UnionFieldNamingPolicy = unionFieldNamingPolicy
+
     member this.UnionTagCaseInsensitive = unionTagCaseInsensitive
 
     member this.AllowNullFields = allowNullFields
@@ -142,7 +148,7 @@ type JsonFSharpOptions
     member this.AllowOverride = allowOverride
 
     member this.WithUnionEncoding(unionEncoding) =
-        JsonFSharpOptions(unionEncoding, unionTagName, unionFieldsName, unionTagNamingPolicy, unionTagCaseInsensitive, allowNullFields, allowOverride)
+        JsonFSharpOptions(unionEncoding, unionTagName, unionFieldsName, unionTagNamingPolicy, unionFieldNamingPolicy, unionTagCaseInsensitive, allowNullFields, allowOverride)
 
 type IJsonFSharpConverterAttribute =
     abstract Options: JsonFSharpOptions

--- a/src/FSharp.SystemTextJson/Options.fs
+++ b/src/FSharp.SystemTextJson/Options.fs
@@ -81,6 +81,9 @@ type JsonUnionEncoding =
     /// where the tag is not the first field in the JSON object.
     | AllowUnorderedTag         = 0x00_00_40_00
 
+    /// When a union field doesn't have an explicit name, use its type as name.
+    | UnionFieldNamesFromTypes  = 0x00_00_80_00
+
 
     //// Specific formats
 

--- a/src/FSharp.SystemTextJson/Union.fs
+++ b/src/FSharp.SystemTextJson/Union.fs
@@ -94,7 +94,11 @@ type JsonUnionConverter<'T>
                     {
                         Type = p.PropertyType
                         Name =
-                            match options.PropertyNamingPolicy with
+                            let policy =
+                                match fsOptions.UnionFieldNamingPolicy with
+                                | null -> options.PropertyNamingPolicy
+                                | policy -> policy
+                            match policy with
                             | null -> name
                             | policy -> policy.ConvertName name
                         MustBeNonNull = not (isNullableFieldType fsOptions p.PropertyType)

--- a/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
@@ -655,6 +655,14 @@ module NonStruct =
         Assert.Equal("""{"Case":"NTD","x":123,"y":"test"}""", JsonSerializer.Serialize(NTD(123, "test"), namedAfterTypesOptions))
         Assert.Equal("""{"Case":"NTE","String1":"123","String2":"test"}""", JsonSerializer.Serialize(NTE("123", "test"), namedAfterTypesOptions))
 
+    [<Fact>]
+    let ``deserialize UnionFieldNamesFromTypes`` () =
+        Assert.Equal(NTA 123, JsonSerializer.Deserialize("""{"Case":"NTA","Int32":123}""", namedAfterTypesOptions))
+        Assert.Equal(NTB(123, "test"), JsonSerializer.Deserialize("""{"Case":"NTB","Int32":123,"String":"test"}""", namedAfterTypesOptions))
+        Assert.Equal(NTC 123, JsonSerializer.Deserialize("""{"Case":"NTC","x":123}""", namedAfterTypesOptions))
+        Assert.Equal(NTD(123, "test"), JsonSerializer.Deserialize("""{"Case":"NTD","x":123,"y":"test"}""", namedAfterTypesOptions))
+        Assert.Equal(NTE("123", "test"), JsonSerializer.Deserialize("""{"Case":"NTE","String1":"123","String2":"test"}""", namedAfterTypesOptions))
+
 module Struct =
 
     [<Struct; JsonFSharpConverter>]
@@ -1288,3 +1296,11 @@ module Struct =
         Assert.Equal("""{"Case":"NTC","x":123}""", JsonSerializer.Serialize(NTC 123, namedAfterTypesOptions))
         Assert.Equal("""{"Case":"NTD","x":123,"y":"test"}""", JsonSerializer.Serialize(NTD(123, "test"), namedAfterTypesOptions))
         Assert.Equal("""{"Case":"NTE","String1":"123","String2":"test"}""", JsonSerializer.Serialize(NTE("123", "test"), namedAfterTypesOptions))
+
+    [<Fact>]
+    let ``deserialize UnionFieldNamesFromTypes`` () =
+        Assert.Equal(NTA 123, JsonSerializer.Deserialize("""{"Case":"NTA","Int32":123}""", namedAfterTypesOptions))
+        Assert.Equal(NTB(123, "test"), JsonSerializer.Deserialize("""{"Case":"NTB","Int32":123,"String":"test"}""", namedAfterTypesOptions))
+        Assert.Equal(NTC 123, JsonSerializer.Deserialize("""{"Case":"NTC","x":123}""", namedAfterTypesOptions))
+        Assert.Equal(NTD(123, "test"), JsonSerializer.Deserialize("""{"Case":"NTD","x":123,"y":"test"}""", namedAfterTypesOptions))
+        Assert.Equal(NTE("123", "test"), JsonSerializer.Deserialize("""{"Case":"NTE","String1":"123","String2":"test"}""", namedAfterTypesOptions))

--- a/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
@@ -640,8 +640,8 @@ module NonStruct =
     type NamedAfterTypes =
         | NTA of int
         | NTB of int * string
-        | NTC of x: int
-        | NTD of x: int * y: string
+        | NTC of X: int
+        | NTD of X: int * Y: string
         | NTE of string * string
 
     let namedAfterTypesOptions = JsonSerializerOptions()
@@ -651,17 +651,38 @@ module NonStruct =
     let ``serialize UnionFieldNamesFromTypes`` () =
         Assert.Equal("""{"Case":"NTA","Int32":123}""", JsonSerializer.Serialize(NTA 123, namedAfterTypesOptions))
         Assert.Equal("""{"Case":"NTB","Int32":123,"String":"test"}""", JsonSerializer.Serialize(NTB(123, "test"), namedAfterTypesOptions))
-        Assert.Equal("""{"Case":"NTC","x":123}""", JsonSerializer.Serialize(NTC 123, namedAfterTypesOptions))
-        Assert.Equal("""{"Case":"NTD","x":123,"y":"test"}""", JsonSerializer.Serialize(NTD(123, "test"), namedAfterTypesOptions))
+        Assert.Equal("""{"Case":"NTC","X":123}""", JsonSerializer.Serialize(NTC 123, namedAfterTypesOptions))
+        Assert.Equal("""{"Case":"NTD","X":123,"Y":"test"}""", JsonSerializer.Serialize(NTD(123, "test"), namedAfterTypesOptions))
         Assert.Equal("""{"Case":"NTE","String1":"123","String2":"test"}""", JsonSerializer.Serialize(NTE("123", "test"), namedAfterTypesOptions))
 
     [<Fact>]
     let ``deserialize UnionFieldNamesFromTypes`` () =
         Assert.Equal(NTA 123, JsonSerializer.Deserialize("""{"Case":"NTA","Int32":123}""", namedAfterTypesOptions))
         Assert.Equal(NTB(123, "test"), JsonSerializer.Deserialize("""{"Case":"NTB","Int32":123,"String":"test"}""", namedAfterTypesOptions))
-        Assert.Equal(NTC 123, JsonSerializer.Deserialize("""{"Case":"NTC","x":123}""", namedAfterTypesOptions))
-        Assert.Equal(NTD(123, "test"), JsonSerializer.Deserialize("""{"Case":"NTD","x":123,"y":"test"}""", namedAfterTypesOptions))
+        Assert.Equal(NTC 123, JsonSerializer.Deserialize("""{"Case":"NTC","X":123}""", namedAfterTypesOptions))
+        Assert.Equal(NTD(123, "test"), JsonSerializer.Deserialize("""{"Case":"NTD","X":123,"Y":"test"}""", namedAfterTypesOptions))
         Assert.Equal(NTE("123", "test"), JsonSerializer.Deserialize("""{"Case":"NTE","String1":"123","String2":"test"}""", namedAfterTypesOptions))
+
+    let namedAfterTypesOptionsWithNamingPolicy = JsonSerializerOptions()
+    namedAfterTypesOptionsWithNamingPolicy.Converters.Add(
+        JsonFSharpConverter(JsonUnionEncoding.InternalTag ||| JsonUnionEncoding.NamedFields ||| JsonUnionEncoding.UnionFieldNamesFromTypes,
+            unionFieldNamingPolicy = JsonNamingPolicy.CamelCase))
+
+    [<Fact>]
+    let ``serialize UnionFieldNamesFromTypes with unionFieldNamingPolicy`` () =
+        Assert.Equal("""{"Case":"NTA","int32":123}""", JsonSerializer.Serialize(NTA 123, namedAfterTypesOptionsWithNamingPolicy))
+        Assert.Equal("""{"Case":"NTB","int32":123,"string":"test"}""", JsonSerializer.Serialize(NTB(123, "test"), namedAfterTypesOptionsWithNamingPolicy))
+        Assert.Equal("""{"Case":"NTC","x":123}""", JsonSerializer.Serialize(NTC 123, namedAfterTypesOptionsWithNamingPolicy))
+        Assert.Equal("""{"Case":"NTD","x":123,"y":"test"}""", JsonSerializer.Serialize(NTD(123, "test"), namedAfterTypesOptionsWithNamingPolicy))
+        Assert.Equal("""{"Case":"NTE","string1":"123","string2":"test"}""", JsonSerializer.Serialize(NTE("123", "test"), namedAfterTypesOptionsWithNamingPolicy))
+
+    [<Fact>]
+    let ``deserialize UnionFieldNamesFromTypes with unionFieldNamingPolicy`` () =
+        Assert.Equal(NTA 123, JsonSerializer.Deserialize("""{"Case":"NTA","int32":123}""", namedAfterTypesOptionsWithNamingPolicy))
+        Assert.Equal(NTB(123, "test"), JsonSerializer.Deserialize("""{"Case":"NTB","int32":123,"string":"test"}""", namedAfterTypesOptionsWithNamingPolicy))
+        Assert.Equal(NTC 123, JsonSerializer.Deserialize("""{"Case":"NTC","x":123}""", namedAfterTypesOptionsWithNamingPolicy))
+        Assert.Equal(NTD(123, "test"), JsonSerializer.Deserialize("""{"Case":"NTD","x":123,"y":"test"}""", namedAfterTypesOptionsWithNamingPolicy))
+        Assert.Equal(NTE("123", "test"), JsonSerializer.Deserialize("""{"Case":"NTE","string1":"123","string2":"test"}""", namedAfterTypesOptionsWithNamingPolicy))
 
 module Struct =
 
@@ -1280,9 +1301,9 @@ module Struct =
     [<Struct>]
     type NamedAfterTypesB = NTB of int * string
     [<Struct>]
-    type NamedAfterTypesC = NTC of x: int
+    type NamedAfterTypesC = NTC of X: int
     [<Struct>]
-    type NamedAfterTypesD = NTD of x: int * y: string
+    type NamedAfterTypesD = NTD of X: int * Y: string
     [<Struct>]
     type NamedAfterTypesE = NTE of string * string
 
@@ -1293,14 +1314,35 @@ module Struct =
     let ``serialize UnionFieldNamesFromTypes`` () =
         Assert.Equal("""{"Case":"NTA","Int32":123}""", JsonSerializer.Serialize(NTA 123, namedAfterTypesOptions))
         Assert.Equal("""{"Case":"NTB","Int32":123,"String":"test"}""", JsonSerializer.Serialize(NTB(123, "test"), namedAfterTypesOptions))
-        Assert.Equal("""{"Case":"NTC","x":123}""", JsonSerializer.Serialize(NTC 123, namedAfterTypesOptions))
-        Assert.Equal("""{"Case":"NTD","x":123,"y":"test"}""", JsonSerializer.Serialize(NTD(123, "test"), namedAfterTypesOptions))
+        Assert.Equal("""{"Case":"NTC","X":123}""", JsonSerializer.Serialize(NTC 123, namedAfterTypesOptions))
+        Assert.Equal("""{"Case":"NTD","X":123,"Y":"test"}""", JsonSerializer.Serialize(NTD(123, "test"), namedAfterTypesOptions))
         Assert.Equal("""{"Case":"NTE","String1":"123","String2":"test"}""", JsonSerializer.Serialize(NTE("123", "test"), namedAfterTypesOptions))
 
     [<Fact>]
     let ``deserialize UnionFieldNamesFromTypes`` () =
         Assert.Equal(NTA 123, JsonSerializer.Deserialize("""{"Case":"NTA","Int32":123}""", namedAfterTypesOptions))
         Assert.Equal(NTB(123, "test"), JsonSerializer.Deserialize("""{"Case":"NTB","Int32":123,"String":"test"}""", namedAfterTypesOptions))
-        Assert.Equal(NTC 123, JsonSerializer.Deserialize("""{"Case":"NTC","x":123}""", namedAfterTypesOptions))
-        Assert.Equal(NTD(123, "test"), JsonSerializer.Deserialize("""{"Case":"NTD","x":123,"y":"test"}""", namedAfterTypesOptions))
+        Assert.Equal(NTC 123, JsonSerializer.Deserialize("""{"Case":"NTC","X":123}""", namedAfterTypesOptions))
+        Assert.Equal(NTD(123, "test"), JsonSerializer.Deserialize("""{"Case":"NTD","X":123,"Y":"test"}""", namedAfterTypesOptions))
         Assert.Equal(NTE("123", "test"), JsonSerializer.Deserialize("""{"Case":"NTE","String1":"123","String2":"test"}""", namedAfterTypesOptions))
+
+    let namedAfterTypesOptionsWithNamingPolicy = JsonSerializerOptions()
+    namedAfterTypesOptionsWithNamingPolicy.Converters.Add(
+        JsonFSharpConverter(JsonUnionEncoding.InternalTag ||| JsonUnionEncoding.NamedFields ||| JsonUnionEncoding.UnionFieldNamesFromTypes,
+            unionFieldNamingPolicy = JsonNamingPolicy.CamelCase))
+
+    [<Fact>]
+    let ``serialize UnionFieldNamesFromTypes with unionFieldNamingPolicy`` () =
+        Assert.Equal("""{"Case":"NTA","int32":123}""", JsonSerializer.Serialize(NTA 123, namedAfterTypesOptionsWithNamingPolicy))
+        Assert.Equal("""{"Case":"NTB","int32":123,"string":"test"}""", JsonSerializer.Serialize(NTB(123, "test"), namedAfterTypesOptionsWithNamingPolicy))
+        Assert.Equal("""{"Case":"NTC","x":123}""", JsonSerializer.Serialize(NTC 123, namedAfterTypesOptionsWithNamingPolicy))
+        Assert.Equal("""{"Case":"NTD","x":123,"y":"test"}""", JsonSerializer.Serialize(NTD(123, "test"), namedAfterTypesOptionsWithNamingPolicy))
+        Assert.Equal("""{"Case":"NTE","string1":"123","string2":"test"}""", JsonSerializer.Serialize(NTE("123", "test"), namedAfterTypesOptionsWithNamingPolicy))
+
+    [<Fact>]
+    let ``deserialize UnionFieldNamesFromTypes with unionFieldNamingPolicy`` () =
+        Assert.Equal(NTA 123, JsonSerializer.Deserialize("""{"Case":"NTA","int32":123}""", namedAfterTypesOptionsWithNamingPolicy))
+        Assert.Equal(NTB(123, "test"), JsonSerializer.Deserialize("""{"Case":"NTB","int32":123,"string":"test"}""", namedAfterTypesOptionsWithNamingPolicy))
+        Assert.Equal(NTC 123, JsonSerializer.Deserialize("""{"Case":"NTC","x":123}""", namedAfterTypesOptionsWithNamingPolicy))
+        Assert.Equal(NTD(123, "test"), JsonSerializer.Deserialize("""{"Case":"NTD","x":123,"y":"test"}""", namedAfterTypesOptionsWithNamingPolicy))
+        Assert.Equal(NTE("123", "test"), JsonSerializer.Deserialize("""{"Case":"NTE","string1":"123","string2":"test"}""", namedAfterTypesOptionsWithNamingPolicy))

--- a/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
@@ -637,6 +637,23 @@ module NonStruct =
         o.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.InternalTag ||| JsonUnionEncoding.NamedFields, overrides = dict [typeof<Override>, JsonFSharpOptions(unionTagName = "tag")]))
         Assert.Equal("""{"tag":"A","x":123,"y":"abc"}""", JsonSerializer.Serialize(Override.A(123, "abc"), o))
 
+    type NamedAfterTypes =
+        | NTA of int
+        | NTB of int * string
+        | NTC of x: int
+        | NTD of x: int * y: string
+        | NTE of string * string
+
+    let namedAfterTypesOptions = JsonSerializerOptions()
+    namedAfterTypesOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.InternalTag ||| JsonUnionEncoding.NamedFields ||| JsonUnionEncoding.UnionFieldNamesFromTypes))
+
+    [<Fact>]
+    let ``serialize UnionFieldNamesFromTypes`` () =
+        Assert.Equal("""{"Case":"NTA","Int32":123}""", JsonSerializer.Serialize(NTA 123, namedAfterTypesOptions))
+        Assert.Equal("""{"Case":"NTB","Int32":123,"String":"test"}""", JsonSerializer.Serialize(NTB(123, "test"), namedAfterTypesOptions))
+        Assert.Equal("""{"Case":"NTC","x":123}""", JsonSerializer.Serialize(NTC 123, namedAfterTypesOptions))
+        Assert.Equal("""{"Case":"NTD","x":123,"y":"test"}""", JsonSerializer.Serialize(NTD(123, "test"), namedAfterTypesOptions))
+        Assert.Equal("""{"Case":"NTE","String1":"123","String2":"test"}""", JsonSerializer.Serialize(NTE("123", "test"), namedAfterTypesOptions))
 
 module Struct =
 
@@ -1249,3 +1266,25 @@ module Struct =
         let o = JsonSerializerOptions()
         o.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.InternalTag ||| JsonUnionEncoding.NamedFields, overrides = dict [typeof<Override>, JsonFSharpOptions(unionTagName = "tag")]))
         Assert.Equal("""{"tag":"A","x":123,"y":"abc"}""", JsonSerializer.Serialize(Override.A(123, "abc"), o))
+
+    [<Struct>]
+    type NamedAfterTypesA = NTA of int
+    [<Struct>]
+    type NamedAfterTypesB = NTB of int * string
+    [<Struct>]
+    type NamedAfterTypesC = NTC of x: int
+    [<Struct>]
+    type NamedAfterTypesD = NTD of x: int * y: string
+    [<Struct>]
+    type NamedAfterTypesE = NTE of string * string
+
+    let namedAfterTypesOptions = JsonSerializerOptions()
+    namedAfterTypesOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.InternalTag ||| JsonUnionEncoding.NamedFields ||| JsonUnionEncoding.UnionFieldNamesFromTypes))
+
+    [<Fact>]
+    let ``serialize UnionFieldNamesFromTypes`` () =
+        Assert.Equal("""{"Case":"NTA","Int32":123}""", JsonSerializer.Serialize(NTA 123, namedAfterTypesOptions))
+        Assert.Equal("""{"Case":"NTB","Int32":123,"String":"test"}""", JsonSerializer.Serialize(NTB(123, "test"), namedAfterTypesOptions))
+        Assert.Equal("""{"Case":"NTC","x":123}""", JsonSerializer.Serialize(NTC 123, namedAfterTypesOptions))
+        Assert.Equal("""{"Case":"NTD","x":123,"y":"test"}""", JsonSerializer.Serialize(NTD(123, "test"), namedAfterTypesOptions))
+        Assert.Equal("""{"Case":"NTE","String1":"123","String2":"test"}""", JsonSerializer.Serialize(NTE("123", "test"), namedAfterTypesOptions))


### PR DESCRIPTION
* [x] Add `JsonUnionEncoding.UnionFieldNamesFromTypes` so that union fields that don't have an explicit name are named after their type instead. If a union case has several fields with the same type, a suffix `1`, `2`, etc is added.
* [x] Add `unionFieldNamingPolicy` option to specify the policy used to name JSON fields for union fields. If unspecified, use the standard `PropertyNamingPolicy`.