### PR TITLE
Add options to serialize record properties

### DIFF
--- a/src/FSharp.SystemTextJson/All.fs
+++ b/src/FSharp.SystemTextJson/All.fs
@@ -37,6 +37,7 @@ type JsonFSharpConverter(fsOptions: JsonFSharpOptions, [<Optional>] overrides: I
         [<Optional; DefaultParameterValue(Default.UnionTagNamingPolicy)>] unionFieldNamingPolicy: JsonNamingPolicy,
         [<Optional; DefaultParameterValue(Default.UnionTagCaseInsensitive)>] unionTagCaseInsensitive: bool,
         [<Optional; DefaultParameterValue(Default.AllowNullFields)>] allowNullFields: bool,
+        [<Optional; DefaultParameterValue(Default.IncludeRecordProperties)>] includeRecordProperties: bool,
         [<Optional; DefaultParameterValue(false)>] allowOverride: bool,
         [<Optional>] overrides: IDictionary<Type, JsonFSharpOptions>) =
         JsonFSharpConverter(
@@ -48,6 +49,7 @@ type JsonFSharpConverter(fsOptions: JsonFSharpOptions, [<Optional>] overrides: I
                 unionFieldNamingPolicy = unionFieldNamingPolicy,
                 unionTagCaseInsensitive = unionTagCaseInsensitive,
                 allowNullFields = allowNullFields,
+                includeRecordProperties = includeRecordProperties,
                 allowOverride = allowOverride
             ),
             overrides
@@ -62,7 +64,8 @@ type JsonFSharpConverterAttribute
         [<Optional; DefaultParameterValue(JsonKnownNamingPolicy.Unspecified)>] unionTagNamingPolicy: JsonKnownNamingPolicy,
         [<Optional; DefaultParameterValue(JsonKnownNamingPolicy.Unspecified)>] unionFieldNamingPolicy: JsonKnownNamingPolicy,
         [<Optional; DefaultParameterValue(Default.UnionTagCaseInsensitive)>] unionTagCaseInsensitive: bool,
-        [<Optional; DefaultParameterValue(Default.AllowNullFields)>] allowNullFields: bool
+        [<Optional; DefaultParameterValue(Default.AllowNullFields)>] allowNullFields: bool,
+        [<Optional; DefaultParameterValue(Default.IncludeRecordProperties)>] includeRecordProperties: bool
     ) =
     inherit JsonConverterAttribute()
 
@@ -83,6 +86,7 @@ type JsonFSharpConverterAttribute
             unionFieldNamingPolicy = namingPolicy unionFieldNamingPolicy,
             unionTagCaseInsensitive = unionTagCaseInsensitive,
             allowNullFields = allowNullFields,
+            includeRecordProperties = includeRecordProperties,
             allowOverride = false
         )
 

--- a/src/FSharp.SystemTextJson/Options.fs
+++ b/src/FSharp.SystemTextJson/Options.fs
@@ -113,6 +113,9 @@ module internal Default =
     let UnionTagCaseInsensitive = false
 
     [<Literal>]
+    let IncludeRecordProperties = false
+
+    [<Literal>]
     let AllowNullFields = false
 
 type JsonFSharpOptions
@@ -124,6 +127,7 @@ type JsonFSharpOptions
         [<Optional; DefaultParameterValue(Default.UnionTagNamingPolicy)>] unionFieldNamingPolicy: JsonNamingPolicy,
         [<Optional; DefaultParameterValue(Default.UnionTagCaseInsensitive)>] unionTagCaseInsensitive: bool,
         [<Optional; DefaultParameterValue(Default.AllowNullFields)>] allowNullFields: bool,
+        [<Optional; DefaultParameterValue(Default.IncludeRecordProperties)>] includeRecordProperties: bool,
         [<Optional; DefaultParameterValue(false)>] allowOverride: bool
     ) =
 
@@ -141,6 +145,8 @@ type JsonFSharpOptions
 
     member this.AllowNullFields = allowNullFields
 
+    member this.IncludeRecordProperties = includeRecordProperties
+
     member this.AllowOverride = allowOverride
 
     member this.WithUnionEncoding(unionEncoding) =
@@ -152,6 +158,7 @@ type JsonFSharpOptions
             unionFieldNamingPolicy = unionFieldNamingPolicy,
             unionTagCaseInsensitive = unionTagCaseInsensitive,
             allowNullFields = allowNullFields,
+            includeRecordProperties = includeRecordProperties,
             allowOverride = allowOverride
         )
 

--- a/src/FSharp.SystemTextJson/Record.fs
+++ b/src/FSharp.SystemTextJson/Record.fs
@@ -4,6 +4,7 @@ namespace System.Text.Json.Serialization
 
 open System
 open System.Collections.Generic
+open System.Reflection
 open System.Text.Json
 open FSharp.Reflection
 open System.Text.Json.Serialization.Helpers
@@ -15,6 +16,7 @@ type internal RecordProperty =
       MustBeNonNull: bool
       MustBePresent: bool
       IsSkip: obj -> bool
+      Read: obj -> obj
       WriteOrder: int }
 
 type internal IRecordConverter =
@@ -29,9 +31,15 @@ type JsonRecordConverter<'T>(options: JsonSerializerOptions, fsOptions: JsonFSha
 
     let fields = FSharpType.GetRecordFields(recordType, true)
 
+    let allProperties =
+        if fsOptions.IncludeRecordProperties then
+            recordType.GetProperties(BindingFlags.Instance ||| BindingFlags.Public)
+        else
+            fields
+
     let fieldOrderIndices =
         let revIndices =
-            fields
+            allProperties
             |> Array.mapi (fun i field ->
                 let revI =
                     match field.GetCustomAttributes(typeof<JsonPropertyOrderAttribute>, true) with
@@ -43,7 +51,7 @@ type JsonRecordConverter<'T>(options: JsonSerializerOptions, fsOptions: JsonFSha
             // Using Seq.sort rather than Array.sort because it is stable
             let revIndices =
                 revIndices |> Seq.sortBy (fun struct (revI, _) -> revI) |> Array.ofSeq
-            let res = Array.zeroCreate fields.Length
+            let res = Array.zeroCreate allProperties.Length
             for i in 0 .. res.Length - 1 do
                 let struct (_, x) = revIndices[i]
                 res[x] <- i
@@ -51,8 +59,8 @@ type JsonRecordConverter<'T>(options: JsonSerializerOptions, fsOptions: JsonFSha
         else
             ValueNone
 
-    let fieldProps =
-        fields
+    let allProps =
+        allProperties
         |> Array.mapi (fun i p ->
             let name =
                 match p.GetCustomAttributes(typeof<JsonPropertyNameAttribute>, true) with
@@ -71,20 +79,29 @@ type JsonRecordConverter<'T>(options: JsonSerializerOptions, fsOptions: JsonFSha
                 ignore
                 || options.IgnoreNullValues
                 || isSkippableFieldType fsOptions p.PropertyType
+            let read =
+                let m = p.GetGetMethod()
+                fun o -> m.Invoke(o, Array.empty)
             { Name = name
               Type = p.PropertyType
               Ignore = ignore
               MustBeNonNull = not canBeNull
               MustBePresent = not canBeSkipped
               IsSkip = isSkip p.PropertyType
+              Read = read
               WriteOrder =
                 match fieldOrderIndices with
                 | ValueSome a -> a[i]
                 | ValueNone -> i }
         )
+    let fieldProps =
+        if fsOptions.IncludeRecordProperties then
+            allProps |> Array.take fields.Length
+        else
+            allProps
 
     let writeOrderedFieldProps =
-        let a = Array.mapi (fun i x -> struct (i, x)) fieldProps
+        let a = Array.mapi (fun i x -> struct (i, x)) allProps
         a |> Array.sortInPlaceBy (fun struct (_, x) -> x.WriteOrder)
         a
 
@@ -185,7 +202,7 @@ type JsonRecordConverter<'T>(options: JsonSerializerOptions, fsOptions: JsonFSha
     member internal _.WriteRestOfObject(writer, value, options) =
         let values = dector value
         for struct (i, p) in writeOrderedFieldProps do
-            let v = values[i]
+            let v = if i < fieldCount then values[i] else p.Read value
             if not p.Ignore && not (options.IgnoreNullValues && isNull v) && not (p.IsSkip v) then
                 writer.WritePropertyName(p.Name)
                 JsonSerializer.Serialize(writer, v, p.Type, options)

--- a/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
@@ -320,6 +320,21 @@ module NonStruct =
             JsonSerializer.Deserialize("""{"CcFirst":1,"CcSecond":"a"}""", includeRecordPropertiesOptions)
         Assert.Equal({ CcFirst = 1; CcSecond = "a" }, actual)
 
+    type RecordWithInclude =
+        { incX: int
+          incY: string }
+
+        [<JsonInclude>]
+        member _.incZ = 42
+
+        member _.incT = "t"
+
+    [<Fact>]
+    let ``serialize with JsonInclude property`` () =
+        let actual =
+            JsonSerializer.Serialize({ incX = 1; incY = "a" }, dontIncludeRecordPropertiesOptions)
+        Assert.Equal("""{"incX":1,"incY":"a","incZ":42}""", actual)
+
 module Struct =
 
     [<Struct; JsonFSharpConverter>]
@@ -599,3 +614,19 @@ module Struct =
         let actual =
             JsonSerializer.Deserialize("""{"CcFirst":1,"CcSecond":"a"}""", includeRecordPropertiesOptions)
         Assert.Equal({ CcFirst = 1; CcSecond = "a" }, actual)
+
+    [<Struct>]
+    type RecordWithInclude =
+        { incX: int
+          incY: string }
+
+        [<JsonInclude>]
+        member _.incZ = 42
+
+        member _.incT = "t"
+
+    [<Fact>]
+    let ``serialize with JsonInclude property`` () =
+        let actual =
+            JsonSerializer.Serialize({ incX = 1; incY = "a" }, dontIncludeRecordPropertiesOptions)
+        Assert.Equal("""{"incX":1,"incY":"a","incZ":42}""", actual)

--- a/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
@@ -291,6 +291,8 @@ module NonStruct =
         { CcFirst: int
           CcSecond: string }
         member _.Member = "b"
+        [<JsonIgnore>]
+        member _.IgnoredMember = "c"
 
     let includeRecordPropertiesOptions =
         JsonSerializerOptions(PropertyNameCaseInsensitive = true)
@@ -586,6 +588,8 @@ module Struct =
         { CcFirst: int
           CcSecond: string }
         member _.Member = "b"
+        [<JsonIgnore>]
+        member _.IgnoredMember = "c"
 
     let includeRecordPropertiesOptions =
         JsonSerializerOptions(PropertyNameCaseInsensitive = true)

--- a/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
@@ -292,11 +292,33 @@ module NonStruct =
           CcSecond: string }
         member _.Member = "b"
 
+    let includeRecordPropertiesOptions =
+        JsonSerializerOptions(PropertyNameCaseInsensitive = true)
+
+    includeRecordPropertiesOptions.Converters.Add(JsonFSharpConverter(includeRecordProperties = true))
+
+    let dontIncludeRecordPropertiesOptions =
+        JsonSerializerOptions(PropertyNameCaseInsensitive = true)
+
+    dontIncludeRecordPropertiesOptions.Converters.Add(JsonFSharpConverter(includeRecordProperties = false))
+
     [<Fact>]
-    let ``serialize record member fields`` () =
+    let ``serialize record properties`` () =
         let actual =
-            JsonSerializer.Serialize({ CcFirst = 1; CcSecond = "a" }, propertyNameCaseInsensitiveOptions)
+            JsonSerializer.Serialize({ CcFirst = 1; CcSecond = "a" }, includeRecordPropertiesOptions)
         Assert.Equal("""{"CcFirst":1,"CcSecond":"a","Member":"b"}""", actual)
+
+    [<Fact>]
+    let ``don't serialize record properties`` () =
+        let actual =
+            JsonSerializer.Serialize({ CcFirst = 1; CcSecond = "a" }, dontIncludeRecordPropertiesOptions)
+        Assert.Equal("""{"CcFirst":1,"CcSecond":"a"}""", actual)
+
+    [<Fact>]
+    let ``deserialize with includeRecordProperties`` () =
+        let actual =
+            JsonSerializer.Deserialize("""{"CcFirst":1,"CcSecond":"a"}""", includeRecordPropertiesOptions)
+        Assert.Equal({ CcFirst = 1; CcSecond = "a" }, actual)
 
 module Struct =
 
@@ -550,8 +572,30 @@ module Struct =
           CcSecond: string }
         member _.Member = "b"
 
+    let includeRecordPropertiesOptions =
+        JsonSerializerOptions(PropertyNameCaseInsensitive = true)
+
+    includeRecordPropertiesOptions.Converters.Add(JsonFSharpConverter(includeRecordProperties = true))
+
+    let dontIncludeRecordPropertiesOptions =
+        JsonSerializerOptions(PropertyNameCaseInsensitive = true)
+
+    dontIncludeRecordPropertiesOptions.Converters.Add(JsonFSharpConverter(includeRecordProperties = false))
+
     [<Fact>]
-    let ``serialize record member fields`` () =
+    let ``serialize record properties`` () =
         let actual =
-            JsonSerializer.Serialize({ CcFirst = 1; CcSecond = "a" }, propertyNameCaseInsensitiveOptions)
+            JsonSerializer.Serialize({ CcFirst = 1; CcSecond = "a" }, includeRecordPropertiesOptions)
         Assert.Equal("""{"CcFirst":1,"CcSecond":"a","Member":"b"}""", actual)
+
+    [<Fact>]
+    let ``don't serialize record properties`` () =
+        let actual =
+            JsonSerializer.Serialize({ CcFirst = 1; CcSecond = "a" }, dontIncludeRecordPropertiesOptions)
+        Assert.Equal("""{"CcFirst":1,"CcSecond":"a"}""", actual)
+
+    [<Fact>]
+    let ``deserialize with includeRecordProperties`` () =
+        let actual =
+            JsonSerializer.Deserialize("""{"CcFirst":1,"CcSecond":"a"}""", includeRecordPropertiesOptions)
+        Assert.Equal({ CcFirst = 1; CcSecond = "a" }, actual)


### PR DESCRIPTION
Add ways to include record properties (rather than just fields) in serialized JSON.

* Add option `includeRecordProperties: bool` to serialize properties of record types (unless ignored with `JsonIgnoreAttribute`).
* Serialize properties of record types that have `JsonIncludeAttribute` (even with `includeRecordProperties = false`).