### PR TITLE
[#89] Add JsonName attribute for union cases with int or bool tags

### DIFF
--- a/FSharp.SystemTextJson.sln
+++ b/FSharp.SystemTextJson.sln
@@ -6,7 +6,6 @@ MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".build", ".build", "{CB1D506A-0E4B-4D73-9B71-A775E5BBED64}"
 	ProjectSection(SolutionItems) = preProject
 		.gitignore = .gitignore
-		appveyor.yml = appveyor.yml
 		build.fsx = build.fsx
 		CHANGELOG.md = CHANGELOG.md
 		paket.dependencies = paket.dependencies

--- a/src/FSharp.SystemTextJson/Collection.fs
+++ b/src/FSharp.SystemTextJson/Collection.fs
@@ -112,10 +112,7 @@ type JsonStringMapConverter<'V>() =
     override _.Write(writer, value, options) =
         writer.WriteStartObject()
         for kv in value do
-            let k =
-                match options.DictionaryKeyPolicy with
-                | null -> kv.Key
-                | p -> p.ConvertName kv.Key
+            let k = convertName options.DictionaryKeyPolicy kv.Key
             writer.WritePropertyName(k)
             JsonSerializer.Serialize<'V>(writer, kv.Value, options)
         writer.WriteEndObject()
@@ -151,9 +148,7 @@ type JsonWrappedStringMapConverter<'K, 'V when 'K: comparison>() =
         for kv in value do
             let k =
                 let k = (unwrap kv.Key)[0] :?> string
-                match options.DictionaryKeyPolicy with
-                | null -> k
-                | p -> p.ConvertName k
+                convertName options.DictionaryKeyPolicy k
             writer.WritePropertyName(k)
             JsonSerializer.Serialize<'V>(writer, kv.Value, options)
         writer.WriteEndObject()

--- a/src/FSharp.SystemTextJson/FSharp.SystemTextJson.fsproj
+++ b/src/FSharp.SystemTextJson/FSharp.SystemTextJson.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="TypeCache.fs" />
     <Compile Include="Skippable.fs" />
     <Compile Include="Options.fs" />
+    <Compile Include="JsonName.fs" />
     <Compile Include="Helpers.fs" />
     <Compile Include="Collection.fs" />
     <Compile Include="Tuple.fs" />

--- a/src/FSharp.SystemTextJson/Helpers.fs
+++ b/src/FSharp.SystemTextJson/Helpers.fs
@@ -144,8 +144,8 @@ let convertName (policy: JsonNamingPolicy) (name: string) =
 
 let getJsonNames (getAttributes: Type -> obj[]) =
     match getAttributes typeof<JsonNameAttribute> with
-    | [||] ->
+    | [| :? JsonNameAttribute as attr |] -> ValueSome attr.AllNames
+    | _ ->
         match getAttributes typeof<JsonPropertyNameAttribute> with
         | [| :? JsonPropertyNameAttribute as attr |] -> ValueSome [| JsonName.String attr.Name |]
         | _ -> ValueNone
-    | attrs -> attrs |> Array.map (fun attr -> (attr :?> JsonNameAttribute).Name) |> ValueSome

--- a/src/FSharp.SystemTextJson/Helpers.fs
+++ b/src/FSharp.SystemTextJson/Helpers.fs
@@ -136,3 +136,8 @@ let overrideOptions (ty: Type) (defaultOptions: JsonFSharpOptions) (overrides: I
 let ignoreNullValues (options: JsonSerializerOptions) =
     options.IgnoreNullValues
     || options.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+
+let convertName (policy: JsonNamingPolicy) (name: string) =
+    match policy with
+    | null -> name
+    | policy -> policy.ConvertName(name)

--- a/src/FSharp.SystemTextJson/Helpers.fs
+++ b/src/FSharp.SystemTextJson/Helpers.fs
@@ -141,3 +141,11 @@ let convertName (policy: JsonNamingPolicy) (name: string) =
     match policy with
     | null -> name
     | policy -> policy.ConvertName(name)
+
+let getJsonName (getAttributes: Type -> obj[]) =
+    match getAttributes typeof<JsonNameAttribute> with
+    | [| :? JsonNameAttribute as attr |] -> ValueSome attr.Name
+    | _ ->
+        match getAttributes typeof<JsonPropertyNameAttribute> with
+        | [| :? JsonPropertyNameAttribute as attr |] -> ValueSome(JsonName.String attr.Name)
+        | _ -> ValueNone

--- a/src/FSharp.SystemTextJson/Helpers.fs
+++ b/src/FSharp.SystemTextJson/Helpers.fs
@@ -142,10 +142,10 @@ let convertName (policy: JsonNamingPolicy) (name: string) =
     | null -> name
     | policy -> policy.ConvertName(name)
 
-let getJsonName (getAttributes: Type -> obj[]) =
+let getJsonNames (getAttributes: Type -> obj[]) =
     match getAttributes typeof<JsonNameAttribute> with
-    | [| :? JsonNameAttribute as attr |] -> ValueSome attr.Name
-    | _ ->
+    | [||] ->
         match getAttributes typeof<JsonPropertyNameAttribute> with
-        | [| :? JsonPropertyNameAttribute as attr |] -> ValueSome(JsonName.String attr.Name)
+        | [| :? JsonPropertyNameAttribute as attr |] -> ValueSome [| JsonName.String attr.Name |]
         | _ -> ValueNone
+    | attrs -> attrs |> Array.map (fun attr -> (attr :?> JsonNameAttribute).Name) |> ValueSome

--- a/src/FSharp.SystemTextJson/JsonName.fs
+++ b/src/FSharp.SystemTextJson/JsonName.fs
@@ -1,5 +1,7 @@
 namespace System.Text.Json.Serialization
 
+#nowarn "42"
+
 open System
 open System.Collections.Generic
 
@@ -44,7 +46,7 @@ type JsonNameComparer(stringComparer: StringComparer) =
         match x with
         | JsonName.String x -> stringComparer.GetHashCode(x)
         | JsonName.Int x -> x ^^^ 226201
-        | JsonName.Bool b -> b.GetHashCode()
+        | JsonName.Bool b -> (# "" b : int #)
 
     interface IEqualityComparer<JsonName> with
 

--- a/src/FSharp.SystemTextJson/JsonName.fs
+++ b/src/FSharp.SystemTextJson/JsonName.fs
@@ -18,7 +18,7 @@ type JsonName =
         | Bool true -> "true"
         | Bool false -> "false"
 
-[<AttributeUsage(AttributeTargets.Property)>]
+[<AttributeUsage(AttributeTargets.Property, AllowMultiple = true)>]
 type JsonNameAttribute(name: JsonName, otherNames: JsonName[]) =
     inherit Attribute()
 
@@ -34,6 +34,9 @@ type JsonNameAttribute(name: JsonName, otherNames: JsonName[]) =
     member _.OtherNames = otherNames
 
     member _.AllNames = Array.append [| name |] otherNames
+
+    /// The name of the union field that this name applies to.
+    member val Field = null: string with get, set
 
     new(name: string, [<ParamArray>] otherNames: obj[]) =
         JsonNameAttribute(JsonName.String name, Array.map convertName otherNames)

--- a/src/FSharp.SystemTextJson/JsonName.fs
+++ b/src/FSharp.SystemTextJson/JsonName.fs
@@ -18,8 +18,7 @@ type JsonName =
         | Bool true -> "true"
         | Bool false -> "false"
 
-// TODO: AllowMultiple = true
-[<AttributeUsage(AttributeTargets.Property)>]
+[<AttributeUsage(AttributeTargets.Property, AllowMultiple = true)>]
 type JsonNameAttribute(name: JsonName) =
     inherit Attribute()
 

--- a/src/FSharp.SystemTextJson/JsonName.fs
+++ b/src/FSharp.SystemTextJson/JsonName.fs
@@ -1,0 +1,55 @@
+namespace System.Text.Json.Serialization
+
+open System
+open System.Collections.Generic
+
+[<RequireQualifiedAccess>]
+type JsonName =
+    | String of string
+    | Int of int
+    | Bool of bool
+
+    member this.AsString() =
+        match this with
+        | String name -> name
+        | Int name -> string name
+        | Bool true -> "true"
+        | Bool false -> "false"
+
+// TODO: AllowMultiple = true
+[<AttributeUsage(AttributeTargets.Property)>]
+type JsonNameAttribute(name: JsonName) =
+    inherit Attribute()
+
+    member _.Name = name
+
+    new(name: string) = JsonNameAttribute(JsonName.String name)
+
+    new(name: int) = JsonNameAttribute(JsonName.Int name)
+
+    new(name: bool) = JsonNameAttribute(JsonName.Bool name)
+
+type JsonNameComparer(stringComparer: StringComparer) =
+
+    static member val OrdinalIgnoreCase = JsonNameComparer(StringComparer.OrdinalIgnoreCase)
+
+    member _.Equals(x, y) =
+        match x, y with
+        | JsonName.String x, JsonName.String y -> stringComparer.Equals(x, y)
+        | JsonName.Int x, JsonName.Int y -> x = y
+        | JsonName.Bool x, JsonName.Bool y -> x = y
+        | _ -> false
+
+    member _.GetHashCode(x) =
+        match x with
+        | JsonName.String x -> stringComparer.GetHashCode(x)
+        | JsonName.Int x -> x ^^^ 226201
+        | JsonName.Bool b -> b.GetHashCode()
+
+    interface IEqualityComparer<JsonName> with
+
+        member this.Equals(x, y) =
+            this.Equals(x, y)
+
+        member this.GetHashCode(obj) =
+            this.GetHashCode(obj)

--- a/src/FSharp.SystemTextJson/JsonName.fs
+++ b/src/FSharp.SystemTextJson/JsonName.fs
@@ -18,17 +18,31 @@ type JsonName =
         | Bool true -> "true"
         | Bool false -> "false"
 
-[<AttributeUsage(AttributeTargets.Property, AllowMultiple = true)>]
-type JsonNameAttribute(name: JsonName) =
+[<AttributeUsage(AttributeTargets.Property)>]
+type JsonNameAttribute(name: JsonName, otherNames: JsonName[]) =
     inherit Attribute()
+
+    static let convertName (name: obj) =
+        match name with
+        | :? string as s -> JsonName.String s
+        | :? int as i -> JsonName.Int i
+        | :? bool as b -> JsonName.Bool b
+        | _ -> invalidArg "otherNames" "JsonName must be a string, int or bool"
 
     member _.Name = name
 
-    new(name: string) = JsonNameAttribute(JsonName.String name)
+    member _.OtherNames = otherNames
 
-    new(name: int) = JsonNameAttribute(JsonName.Int name)
+    member _.AllNames = Array.append [| name |] otherNames
 
-    new(name: bool) = JsonNameAttribute(JsonName.Bool name)
+    new(name: string, [<ParamArray>] otherNames: obj[]) =
+        JsonNameAttribute(JsonName.String name, Array.map convertName otherNames)
+
+    new(name: int, [<ParamArray>] otherNames: obj[]) =
+        JsonNameAttribute(JsonName.Int name, Array.map convertName otherNames)
+
+    new(name: bool, [<ParamArray>] otherNames: obj[]) =
+        JsonNameAttribute(JsonName.Bool name, Array.map convertName otherNames)
 
 type JsonNameComparer(stringComparer: StringComparer) =
 

--- a/src/FSharp.SystemTextJson/Record.fs
+++ b/src/FSharp.SystemTextJson/Record.fs
@@ -66,7 +66,7 @@ type JsonRecordConverter<'T>(options: JsonSerializerOptions, fsOptions: JsonFSha
         allProperties
         |> Array.mapi (fun i p ->
             let names =
-                match getJsonNames (fun ty -> p.GetCustomAttributes(ty, true)) with
+                match getJsonNames "field" (fun ty -> p.GetCustomAttributes(ty, true)) with
                 | ValueSome names -> names |> Array.map (fun n -> n.AsString())
                 | ValueNone -> [| convertName options.PropertyNamingPolicy p.Name |]
             let ignore =

--- a/src/FSharp.SystemTextJson/Record.fs
+++ b/src/FSharp.SystemTextJson/Record.fs
@@ -68,10 +68,7 @@ type JsonRecordConverter<'T>(options: JsonSerializerOptions, fsOptions: JsonFSha
             let name =
                 match p.GetCustomAttributes(typeof<JsonPropertyNameAttribute>, true) with
                 | [| :? JsonPropertyNameAttribute as name |] -> name.Name
-                | _ ->
-                    match options.PropertyNamingPolicy with
-                    | null -> p.Name
-                    | policy -> policy.ConvertName p.Name
+                | _ -> convertName options.PropertyNamingPolicy p.Name
             let ignore =
                 p.GetCustomAttributes(typeof<JsonIgnoreAttribute>, true) |> Array.isEmpty |> not
             let nullValue = tryGetNullValue fsOptions p.PropertyType

--- a/src/FSharp.SystemTextJson/Record.fs
+++ b/src/FSharp.SystemTextJson/Record.fs
@@ -8,7 +8,7 @@ open FSharp.Reflection
 open System.Text.Json.Serialization.Helpers
 
 type internal RecordProperty =
-    { Name: string
+    { Names: string[]
       Type: Type
       Ignore: bool
       NullValue: obj voption
@@ -65,10 +65,10 @@ type JsonRecordConverter<'T>(options: JsonSerializerOptions, fsOptions: JsonFSha
     let allProps =
         allProperties
         |> Array.mapi (fun i p ->
-            let name =
+            let names =
                 match getJsonNames (fun ty -> p.GetCustomAttributes(ty, true)) with
-                | ValueSome names -> names[0]
-                | ValueNone -> JsonName.String(convertName options.PropertyNamingPolicy p.Name)
+                | ValueSome names -> names |> Array.map (fun n -> n.AsString())
+                | ValueNone -> [| convertName options.PropertyNamingPolicy p.Name |]
             let ignore =
                 p.GetCustomAttributes(typeof<JsonIgnoreAttribute>, true) |> Array.isEmpty |> not
             let nullValue = tryGetNullValue fsOptions p.PropertyType
@@ -77,7 +77,7 @@ type JsonRecordConverter<'T>(options: JsonSerializerOptions, fsOptions: JsonFSha
             let read =
                 let m = p.GetGetMethod()
                 fun o -> m.Invoke(o, Array.empty)
-            { Name = name.AsString()
+            { Names = names
               Type = p.PropertyType
               Ignore = ignore
               NullValue = nullValue
@@ -123,7 +123,11 @@ type JsonRecordConverter<'T>(options: JsonSerializerOptions, fsOptions: JsonFSha
         if options.PropertyNameCaseInsensitive then
             let d = Dictionary(StringComparer.OrdinalIgnoreCase)
             fieldProps
-            |> Array.iteri (fun i f -> if not f.Ignore then d[f.Name] <- struct (i, f))
+            |> Array.iteri (fun i f ->
+                if not f.Ignore then
+                    for name in f.Names do
+                        d[name] <- struct (i, f)
+            )
             ValueSome d
         else
             ValueNone
@@ -135,10 +139,13 @@ type JsonRecordConverter<'T>(options: JsonSerializerOptions, fsOptions: JsonFSha
             let mutable i = 0
             while found.IsNone && i < fieldCount do
                 let p = fieldProps[i]
-                if reader.ValueTextEquals(p.Name) then
-                    found <- ValueSome(struct (i, p))
-                else
-                    i <- i + 1
+                let mutable j = 0
+                while found.IsNone && j < p.Names.Length do
+                    if reader.ValueTextEquals(p.Names[j]) then
+                        found <- ValueSome(struct (i, p))
+                    else
+                        j <- j + 1
+                i <- i + 1
             found
         | ValueSome d ->
             match d.TryGetValue(reader.GetString()) with
@@ -170,7 +177,7 @@ type JsonRecordConverter<'T>(options: JsonSerializerOptions, fsOptions: JsonFSha
                             failf
                                 "%s.%s was expected to be of type %s, but was null."
                                 recordType.Name
-                                p.Name
+                                p.Names[0]
                                 p.Type.Name
                     else
                         fields[i] <- JsonSerializer.Deserialize(&reader, p.Type, options)
@@ -180,7 +187,7 @@ type JsonRecordConverter<'T>(options: JsonSerializerOptions, fsOptions: JsonFSha
         if requiredFieldCount < minExpectedFieldCount && not (ignoreNullValues options) then
             for i in 0 .. fieldCount - 1 do
                 if isNull fields[i] && fieldProps[i].MustBePresent then
-                    failf "Missing field for record type %s: %s" recordType.FullName fieldProps[i].Name
+                    failf "Missing field for record type %s: %s" recordType.FullName fieldProps[i].Names[0]
 
         ctor fields :?> 'T
 
@@ -193,7 +200,7 @@ type JsonRecordConverter<'T>(options: JsonSerializerOptions, fsOptions: JsonFSha
         for struct (i, p) in writeOrderedFieldProps do
             let v = if i < fieldCount then values[i] else p.Read value
             if not p.Ignore && not (ignoreNullValues options && isNull v) && not (p.IsSkip v) then
-                writer.WritePropertyName(p.Name)
+                writer.WritePropertyName(p.Names[0])
                 JsonSerializer.Serialize(writer, v, p.Type, options)
         writer.WriteEndObject()
 
@@ -202,7 +209,7 @@ type JsonRecordConverter<'T>(options: JsonSerializerOptions, fsOptions: JsonFSha
             box (this.ReadRestOfObject(&reader, options, skipFirstRead))
         member this.WriteRestOfObject(writer, value, options) =
             this.WriteRestOfObject(writer, unbox value, options)
-        member _.FieldNames = fieldProps |> Array.map (fun p -> p.Name)
+        member _.FieldNames = fieldProps |> Array.collect (fun p -> p.Names)
 
 type JsonRecordConverter(fsOptions: JsonFSharpOptions) =
     inherit JsonConverterFactory()

--- a/src/FSharp.SystemTextJson/Record.fs
+++ b/src/FSharp.SystemTextJson/Record.fs
@@ -66,8 +66,8 @@ type JsonRecordConverter<'T>(options: JsonSerializerOptions, fsOptions: JsonFSha
         allProperties
         |> Array.mapi (fun i p ->
             let name =
-                match getJsonName (fun ty -> p.GetCustomAttributes(ty, true)) with
-                | ValueSome name -> name
+                match getJsonNames (fun ty -> p.GetCustomAttributes(ty, true)) with
+                | ValueSome names -> names[0]
                 | ValueNone -> JsonName.String(convertName options.PropertyNamingPolicy p.Name)
             let ignore =
                 p.GetCustomAttributes(typeof<JsonIgnoreAttribute>, true) |> Array.isEmpty |> not

--- a/src/FSharp.SystemTextJson/Union.fs
+++ b/src/FSharp.SystemTextJson/Union.fs
@@ -52,13 +52,9 @@ type JsonUnionConverter<'T>
         cases
         |> Array.map (fun uci ->
             let name =
-                match uci.GetCustomAttributes(typeof<JsonNameAttribute>) with
-                | [| :? JsonNameAttribute as name |] -> name.Name
-                | _ ->
-                    match uci.GetCustomAttributes(typeof<JsonPropertyNameAttribute>) with
-                    | [| :? JsonPropertyNameAttribute as name |] -> name.Name
-                    | _ -> convertName fsOptions.UnionTagNamingPolicy uci.Name
-                    |> JsonName.String
+                match getJsonName uci.GetCustomAttributes with
+                | ValueSome name -> name
+                | ValueNone -> JsonName.String(convertName fsOptions.UnionTagNamingPolicy uci.Name)
             let fields =
                 let fields = uci.GetFields()
                 let usedFieldNames = Dictionary()

--- a/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
@@ -155,7 +155,7 @@ module NonStruct =
 
     type PropJsonName =
         { unnamedA: int
-          [<JsonName "namedB"; JsonName "namedB2">]
+          [<JsonName("namedB", "namedB2")>]
           unnamedB: string }
 
     [<Fact>]
@@ -522,7 +522,7 @@ module Struct =
     [<Struct>]
     type PropJsonName =
         { unnamedA: int
-          [<JsonName "namedB"; JsonName "namedB2">]
+          [<JsonName("namedB", "namedB2")>]
           unnamedB: string }
 
     [<Fact>]

--- a/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
@@ -6,10 +6,6 @@ open System.Text.Json
 
 module NonStruct =
 
-    type Foo() =
-        [<JsonPropertyName "Baz">]
-        member val FooBar = 1 with get, set
-
     [<JsonFSharpConverter>]
     type A = { ax: int; ay: string }
 
@@ -156,6 +152,21 @@ module NonStruct =
     let ``serialize with JsonPropertyName`` () =
         let actual = JsonSerializer.Serialize({ unnamedX = 1; unnamedY = "b" }, options)
         Assert.Equal("""{"unnamedX":1,"namedY":"b"}""", actual)
+
+    type PropJsonName =
+        { unnamedA: int
+          [<JsonName "namedB">]
+          unnamedB: string }
+
+    [<Fact>]
+    let ``deserialize with JsonName`` () =
+        let actual = JsonSerializer.Deserialize("""{"unnamedA":1,"namedB":"b"}""", options)
+        Assert.Equal({ unnamedA = 1; unnamedB = "b" }, actual)
+
+    [<Fact>]
+    let ``serialize with JsonName`` () =
+        let actual = JsonSerializer.Serialize({ unnamedA = 1; unnamedB = "b" }, options)
+        Assert.Equal("""{"unnamedA":1,"namedB":"b"}""", actual)
 
     type IgnoreField =
         { unignoredX: int
@@ -505,6 +516,22 @@ module Struct =
     let ``serialize with JsonPropertyName`` () =
         let actual = JsonSerializer.Serialize({ unnamedX = 1; unnamedY = "b" }, options)
         Assert.Equal("""{"unnamedX":1,"namedY":"b"}""", actual)
+
+    [<Struct>]
+    type PropJsonName =
+        { unnamedA: int
+          [<JsonName "namedB">]
+          unnamedB: string }
+
+    [<Fact>]
+    let ``deserialize with JsonName`` () =
+        let actual = JsonSerializer.Deserialize("""{"unnamedA":1,"namedB":"b"}""", options)
+        Assert.Equal({ unnamedA = 1; unnamedB = "b" }, actual)
+
+    [<Fact>]
+    let ``serialize with JsonName`` () =
+        let actual = JsonSerializer.Serialize({ unnamedA = 1; unnamedB = "b" }, options)
+        Assert.Equal("""{"unnamedA":1,"namedB":"b"}""", actual)
 
     [<Struct>]
     type IgnoreField =

--- a/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
@@ -155,12 +155,14 @@ module NonStruct =
 
     type PropJsonName =
         { unnamedA: int
-          [<JsonName "namedB">]
+          [<JsonName "namedB"; JsonName "namedB2">]
           unnamedB: string }
 
     [<Fact>]
     let ``deserialize with JsonName`` () =
         let actual = JsonSerializer.Deserialize("""{"unnamedA":1,"namedB":"b"}""", options)
+        Assert.Equal({ unnamedA = 1; unnamedB = "b" }, actual)
+        let actual = JsonSerializer.Deserialize("""{"unnamedA":1,"namedB2":"b"}""", options)
         Assert.Equal({ unnamedA = 1; unnamedB = "b" }, actual)
 
     [<Fact>]
@@ -520,12 +522,14 @@ module Struct =
     [<Struct>]
     type PropJsonName =
         { unnamedA: int
-          [<JsonName "namedB">]
+          [<JsonName "namedB"; JsonName "namedB2">]
           unnamedB: string }
 
     [<Fact>]
     let ``deserialize with JsonName`` () =
         let actual = JsonSerializer.Deserialize("""{"unnamedA":1,"namedB":"b"}""", options)
+        Assert.Equal({ unnamedA = 1; unnamedB = "b" }, actual)
+        let actual = JsonSerializer.Deserialize("""{"unnamedA":1,"namedB2":"b"}""", options)
         Assert.Equal({ unnamedA = 1; unnamedB = "b" }, actual)
 
     [<Fact>]

--- a/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
@@ -33,7 +33,7 @@ module NonStruct =
     type JN =
         | [<JsonName "jstring">] JNs of jnsField: int
         | [<JsonName 42>] JNi of jniField: int
-        | [<JsonName true>] JNb of jnbField: int
+        | [<JsonName true; JsonName "jbool">] JNb of jnbField: int
         | JNn of jnnField: int
 
     let options = JsonSerializerOptions()
@@ -124,6 +124,7 @@ module NonStruct =
         Assert.Equal(JNs 1, JsonSerializer.Deserialize("""{"Case":"jstring","Fields":[1]}""", options))
         Assert.Equal(JNi 1, JsonSerializer.Deserialize("""{"Case":42,"Fields":[1]}""", options))
         Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"Case":true,"Fields":[1]}""", options))
+        Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"Case":"jbool","Fields":[1]}""", options))
         Assert.Equal(JNn 1, JsonSerializer.Deserialize("""{"Case":"JNn","Fields":[1]}""", options))
 
     [<Fact>]
@@ -187,6 +188,7 @@ module NonStruct =
         Assert.Equal(JNs 1, JsonSerializer.Deserialize("""{"jstring":[1]}""", externalTagOptions))
         Assert.Equal(JNi 1, JsonSerializer.Deserialize("""{"42":[1]}""", externalTagOptions))
         Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"true":[1]}""", externalTagOptions))
+        Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"jbool":[1]}""", externalTagOptions))
         Assert.Equal(JNn 1, JsonSerializer.Deserialize("""{"JNn":[1]}""", externalTagOptions))
 
     [<Fact>]
@@ -234,6 +236,7 @@ module NonStruct =
         Assert.Equal(JNs 1, JsonSerializer.Deserialize("""["jstring",1]""", internalTagOptions))
         Assert.Equal(JNi 1, JsonSerializer.Deserialize("""[42,1]""", internalTagOptions))
         Assert.Equal(JNb 1, JsonSerializer.Deserialize("""[true,1]""", internalTagOptions))
+        Assert.Equal(JNb 1, JsonSerializer.Deserialize("""["jbool",1]""", internalTagOptions))
         Assert.Equal(JNn 1, JsonSerializer.Deserialize("""["JNn",1]""", internalTagOptions))
 
     [<Fact>]
@@ -376,6 +379,10 @@ module NonStruct =
             JsonSerializer.Deserialize("""{"Case":true,"Fields":{"jnbField":1}}""", adjacentTagNamedFieldsOptions)
         )
         Assert.Equal(
+            JNb 1,
+            JsonSerializer.Deserialize("""{"Case":"jbool","Fields":{"jnbField":1}}""", adjacentTagNamedFieldsOptions)
+        )
+        Assert.Equal(
             JNn 1,
             JsonSerializer.Deserialize("""{"Case":"JNn","Fields":{"jnnField":1}}""", adjacentTagNamedFieldsOptions)
         )
@@ -458,6 +465,7 @@ module NonStruct =
         Assert.Equal(JNs 1, JsonSerializer.Deserialize("""{"jstring":{"jnsField":1}}""", externalTagNamedFieldsOptions))
         Assert.Equal(JNi 1, JsonSerializer.Deserialize("""{"42":{"jniField":1}}""", externalTagNamedFieldsOptions))
         Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"true":{"jnbField":1}}""", externalTagNamedFieldsOptions))
+        Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"jbool":{"jnbField":1}}""", externalTagNamedFieldsOptions))
         Assert.Equal(JNn 1, JsonSerializer.Deserialize("""{"JNn":{"jnnField":1}}""", externalTagNamedFieldsOptions))
 
     [<Fact>]
@@ -591,6 +599,10 @@ module NonStruct =
         )
         Assert.Equal(JNi 1, JsonSerializer.Deserialize("""{"Case":42,"jniField":1}""", internalTagNamedFieldsOptions))
         Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"Case":true,"jnbField":1}""", internalTagNamedFieldsOptions))
+        Assert.Equal(
+            JNb 1,
+            JsonSerializer.Deserialize("""{"Case":"jbool","jnbField":1}""", internalTagNamedFieldsOptions)
+        )
         Assert.Equal(
             JNn 1,
             JsonSerializer.Deserialize("""{"Case":"JNn","jnnField":1}""", internalTagNamedFieldsOptions)
@@ -1266,7 +1278,7 @@ module Struct =
     type JN =
         | [<JsonName "jstring">] JNs of jnsField: int
         | [<JsonName 42>] JNi of jniField: int
-        | [<JsonName true>] JNb of jnbField: int
+        | [<JsonName true; JsonName "jbool">] JNb of jnbField: int
         | JNn of jnnField: int
 
     let options = JsonSerializerOptions()
@@ -1370,6 +1382,7 @@ module Struct =
         Assert.Equal(JNs 1, JsonSerializer.Deserialize("""{"Case":"jstring","Fields":[1]}""", options))
         Assert.Equal(JNi 1, JsonSerializer.Deserialize("""{"Case":42,"Fields":[1]}""", options))
         Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"Case":true,"Fields":[1]}""", options))
+        Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"Case":"jbool","Fields":[1]}""", options))
         Assert.Equal(JNn 1, JsonSerializer.Deserialize("""{"Case":"JNn","Fields":[1]}""", options))
 
     [<Fact>]
@@ -1417,6 +1430,7 @@ module Struct =
         Assert.Equal(JNs 1, JsonSerializer.Deserialize("""{"jstring":[1]}""", externalTagOptions))
         Assert.Equal(JNi 1, JsonSerializer.Deserialize("""{"42":[1]}""", externalTagOptions))
         Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"true":[1]}""", externalTagOptions))
+        Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"jbool":[1]}""", externalTagOptions))
         Assert.Equal(JNn 1, JsonSerializer.Deserialize("""{"JNn":[1]}""", externalTagOptions))
 
     [<Fact>]
@@ -1464,6 +1478,7 @@ module Struct =
         Assert.Equal(JNs 1, JsonSerializer.Deserialize("""["jstring",1]""", internalTagOptions))
         Assert.Equal(JNi 1, JsonSerializer.Deserialize("""[42,1]""", internalTagOptions))
         Assert.Equal(JNb 1, JsonSerializer.Deserialize("""[true,1]""", internalTagOptions))
+        Assert.Equal(JNb 1, JsonSerializer.Deserialize("""["jbool",1]""", internalTagOptions))
         Assert.Equal(JNn 1, JsonSerializer.Deserialize("""["JNn",1]""", internalTagOptions))
 
     [<Fact>]
@@ -1606,6 +1621,10 @@ module Struct =
             JsonSerializer.Deserialize("""{"Case":true,"Fields":{"jnbField":1}}""", adjacentTagNamedFieldsOptions)
         )
         Assert.Equal(
+            JNb 1,
+            JsonSerializer.Deserialize("""{"Case":"jbool","Fields":{"jnbField":1}}""", adjacentTagNamedFieldsOptions)
+        )
+        Assert.Equal(
             JNn 1,
             JsonSerializer.Deserialize("""{"Case":"JNn","Fields":{"jnnField":1}}""", adjacentTagNamedFieldsOptions)
         )
@@ -1688,6 +1707,7 @@ module Struct =
         Assert.Equal(JNs 1, JsonSerializer.Deserialize("""{"jstring":{"jnsField":1}}""", externalTagNamedFieldsOptions))
         Assert.Equal(JNi 1, JsonSerializer.Deserialize("""{"42":{"jniField":1}}""", externalTagNamedFieldsOptions))
         Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"true":{"jnbField":1}}""", externalTagNamedFieldsOptions))
+        Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"jbool":{"jnbField":1}}""", externalTagNamedFieldsOptions))
         Assert.Equal(JNn 1, JsonSerializer.Deserialize("""{"JNn":{"jnnField":1}}""", externalTagNamedFieldsOptions))
 
     [<Fact>]
@@ -1822,6 +1842,10 @@ module Struct =
         )
         Assert.Equal(JNi 1, JsonSerializer.Deserialize("""{"Case":42,"jniField":1}""", internalTagNamedFieldsOptions))
         Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"Case":true,"jnbField":1}""", internalTagNamedFieldsOptions))
+        Assert.Equal(
+            JNb 1,
+            JsonSerializer.Deserialize("""{"Case":"jbool","jnbField":1}""", internalTagNamedFieldsOptions)
+        )
         Assert.Equal(
             JNn 1,
             JsonSerializer.Deserialize("""{"Case":"JNn","jnnField":1}""", internalTagNamedFieldsOptions)

--- a/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
@@ -30,6 +30,12 @@ module NonStruct =
         | Bb of int
         | Bc of x: string * bool
 
+    type JN =
+        | [<JsonName "jstring">] JNs of jnsField: int
+        | [<JsonName 42>] JNi of jniField: int
+        | [<JsonName true>] JNb of jnbField: int
+        | JNn of jnnField: int
+
     let options = JsonSerializerOptions()
     options.Converters.Add(JsonFSharpConverter())
 
@@ -113,6 +119,20 @@ module NonStruct =
             JsonSerializer.Serialize(Bc("test", true), tagCaseInsensitiveOptions)
         )
 
+    [<Fact>]
+    let ``deserialize AdjacentTag with JsonName`` () =
+        Assert.Equal(JNs 1, JsonSerializer.Deserialize("""{"Case":"jstring","Fields":[1]}""", options))
+        Assert.Equal(JNi 1, JsonSerializer.Deserialize("""{"Case":42,"Fields":[1]}""", options))
+        Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"Case":true,"Fields":[1]}""", options))
+        Assert.Equal(JNn 1, JsonSerializer.Deserialize("""{"Case":"JNn","Fields":[1]}""", options))
+
+    [<Fact>]
+    let ``serialize AdjacentTag with JsonName`` () =
+        Assert.Equal("""{"Case":"jstring","Fields":[1]}""", JsonSerializer.Serialize(JNs 1, options))
+        Assert.Equal("""{"Case":42,"Fields":[1]}""", JsonSerializer.Serialize(JNi 1, options))
+        Assert.Equal("""{"Case":true,"Fields":[1]}""", JsonSerializer.Serialize(JNb 1, options))
+        Assert.Equal("""{"Case":"JNn","Fields":[1]}""", JsonSerializer.Serialize(JNn 1, options))
+
     [<CompilationRepresentation(CompilationRepresentationFlags.UseNullAsTrueValue)>]
     type C =
         | Ca
@@ -162,6 +182,20 @@ module NonStruct =
         Assert.Equal("""{"bb":[32]}""", JsonSerializer.Serialize(Bb 32, externalTagPolicyOptions))
         Assert.Equal("""{"bc":["test",true]}""", JsonSerializer.Serialize(Bc("test", true), externalTagPolicyOptions))
 
+    [<Fact>]
+    let ``deserialize ExternalTag with JsonName`` () =
+        Assert.Equal(JNs 1, JsonSerializer.Deserialize("""{"jstring":[1]}""", externalTagOptions))
+        Assert.Equal(JNi 1, JsonSerializer.Deserialize("""{"42":[1]}""", externalTagOptions))
+        Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"true":[1]}""", externalTagOptions))
+        Assert.Equal(JNn 1, JsonSerializer.Deserialize("""{"JNn":[1]}""", externalTagOptions))
+
+    [<Fact>]
+    let ``serialize ExternalTag with JsonName`` () =
+        Assert.Equal("""{"jstring":[1]}""", JsonSerializer.Serialize(JNs 1, externalTagOptions))
+        Assert.Equal("""{"42":[1]}""", JsonSerializer.Serialize(JNi 1, externalTagOptions))
+        Assert.Equal("""{"true":[1]}""", JsonSerializer.Serialize(JNb 1, externalTagOptions))
+        Assert.Equal("""{"JNn":[1]}""", JsonSerializer.Serialize(JNn 1, externalTagOptions))
+
     let internalTagOptions = JsonSerializerOptions()
     internalTagOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.InternalTag))
 
@@ -195,6 +229,20 @@ module NonStruct =
         Assert.Equal("""["bb",32]""", JsonSerializer.Serialize(Bb 32, internalTagPolicyOptions))
         Assert.Equal("""["bc","test",true]""", JsonSerializer.Serialize(Bc("test", true), internalTagPolicyOptions))
 
+    [<Fact>]
+    let ``deserialize InternalTag with JsonName`` () =
+        Assert.Equal(JNs 1, JsonSerializer.Deserialize("""["jstring",1]""", internalTagOptions))
+        Assert.Equal(JNi 1, JsonSerializer.Deserialize("""[42,1]""", internalTagOptions))
+        Assert.Equal(JNb 1, JsonSerializer.Deserialize("""[true,1]""", internalTagOptions))
+        Assert.Equal(JNn 1, JsonSerializer.Deserialize("""["JNn",1]""", internalTagOptions))
+
+    [<Fact>]
+    let ``serialize InternalTag with JsonName`` () =
+        Assert.Equal("""["jstring",1]""", JsonSerializer.Serialize(JNs 1, internalTagOptions))
+        Assert.Equal("""[42,1]""", JsonSerializer.Serialize(JNi 1, internalTagOptions))
+        Assert.Equal("""[true,1]""", JsonSerializer.Serialize(JNb 1, internalTagOptions))
+        Assert.Equal("""["JNn",1]""", JsonSerializer.Serialize(JNn 1, internalTagOptions))
+
     let untaggedOptions = JsonSerializerOptions()
     untaggedOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.Untagged))
 
@@ -209,6 +257,20 @@ module NonStruct =
         Assert.Equal("""{}""", JsonSerializer.Serialize(Ba, untaggedOptions))
         Assert.Equal("""{"Item":32}""", JsonSerializer.Serialize(Bb 32, untaggedOptions))
         Assert.Equal("""{"x":"test","Item2":true}""", JsonSerializer.Serialize(Bc("test", true), untaggedOptions))
+
+    [<Fact>]
+    let ``deserialize Untagged with JsonName`` () =
+        Assert.Equal(JNs 1, JsonSerializer.Deserialize("""{"jnsField":1}""", untaggedOptions))
+        Assert.Equal(JNi 1, JsonSerializer.Deserialize("""{"jniField":1}""", untaggedOptions))
+        Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"jnbField":1}""", untaggedOptions))
+        Assert.Equal(JNn 1, JsonSerializer.Deserialize("""{"jnnField":1}""", untaggedOptions))
+
+    [<Fact>]
+    let ``serialize Untagged with JsonName`` () =
+        Assert.Equal("""{"jnsField":1}""", JsonSerializer.Serialize(JNs 1, untaggedOptions))
+        Assert.Equal("""{"jniField":1}""", JsonSerializer.Serialize(JNi 1, untaggedOptions))
+        Assert.Equal("""{"jnbField":1}""", JsonSerializer.Serialize(JNb 1, untaggedOptions))
+        Assert.Equal("""{"jnnField":1}""", JsonSerializer.Serialize(JNn 1, untaggedOptions))
 
     let adjacentTagNamedFieldsOptions = JsonSerializerOptions()
 
@@ -299,6 +361,44 @@ module NonStruct =
             JsonSerializer.Serialize(Bc("test", true), adjacentTagNamedFieldsTagPolicyOptions)
         )
 
+    [<Fact>]
+    let ``deserialize AdjacentTag NamedFields with JsonName`` () =
+        Assert.Equal(
+            JNs 1,
+            JsonSerializer.Deserialize("""{"Case":"jstring","Fields":{"jnsField":1}}""", adjacentTagNamedFieldsOptions)
+        )
+        Assert.Equal(
+            JNi 1,
+            JsonSerializer.Deserialize("""{"Case":42,"Fields":{"jniField":1}}""", adjacentTagNamedFieldsOptions)
+        )
+        Assert.Equal(
+            JNb 1,
+            JsonSerializer.Deserialize("""{"Case":true,"Fields":{"jnbField":1}}""", adjacentTagNamedFieldsOptions)
+        )
+        Assert.Equal(
+            JNn 1,
+            JsonSerializer.Deserialize("""{"Case":"JNn","Fields":{"jnnField":1}}""", adjacentTagNamedFieldsOptions)
+        )
+
+    [<Fact>]
+    let ``serialize AdjacentTag NamedFields with JsonName`` () =
+        Assert.Equal(
+            """{"Case":"jstring","Fields":{"jnsField":1}}""",
+            JsonSerializer.Serialize(JNs 1, adjacentTagNamedFieldsOptions)
+        )
+        Assert.Equal(
+            """{"Case":42,"Fields":{"jniField":1}}""",
+            JsonSerializer.Serialize(JNi 1, adjacentTagNamedFieldsOptions)
+        )
+        Assert.Equal(
+            """{"Case":true,"Fields":{"jnbField":1}}""",
+            JsonSerializer.Serialize(JNb 1, adjacentTagNamedFieldsOptions)
+        )
+        Assert.Equal(
+            """{"Case":"JNn","Fields":{"jnnField":1}}""",
+            JsonSerializer.Serialize(JNn 1, adjacentTagNamedFieldsOptions)
+        )
+
     let externalTagNamedFieldsOptions = JsonSerializerOptions()
 
     externalTagNamedFieldsOptions.Converters.Add(
@@ -352,6 +452,20 @@ module NonStruct =
             """{"bc":{"x":"test","Item2":true}}""",
             JsonSerializer.Serialize(Bc("test", true), externalTagNamedFieldsTagPolicyOptions)
         )
+
+    [<Fact>]
+    let ``deserialize ExternalTag NamedFields with JsonName`` () =
+        Assert.Equal(JNs 1, JsonSerializer.Deserialize("""{"jstring":{"jnsField":1}}""", externalTagNamedFieldsOptions))
+        Assert.Equal(JNi 1, JsonSerializer.Deserialize("""{"42":{"jniField":1}}""", externalTagNamedFieldsOptions))
+        Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"true":{"jnbField":1}}""", externalTagNamedFieldsOptions))
+        Assert.Equal(JNn 1, JsonSerializer.Deserialize("""{"JNn":{"jnnField":1}}""", externalTagNamedFieldsOptions))
+
+    [<Fact>]
+    let ``serialize ExternalTag NamedFields with JsonName`` () =
+        Assert.Equal("""{"jstring":{"jnsField":1}}""", JsonSerializer.Serialize(JNs 1, externalTagNamedFieldsOptions))
+        Assert.Equal("""{"42":{"jniField":1}}""", JsonSerializer.Serialize(JNi 1, externalTagNamedFieldsOptions))
+        Assert.Equal("""{"true":{"jnbField":1}}""", JsonSerializer.Serialize(JNb 1, externalTagNamedFieldsOptions))
+        Assert.Equal("""{"JNn":{"jnnField":1}}""", JsonSerializer.Serialize(JNn 1, externalTagNamedFieldsOptions))
 
     let internalTagNamedFieldsOptions = JsonSerializerOptions()
 
@@ -468,6 +582,29 @@ module NonStruct =
             """{"Case":"bc","x":"test","Item2":true}""",
             JsonSerializer.Serialize(Bc("test", true), internalTagNamedFieldsTagPolicyOptions)
         )
+
+    [<Fact>]
+    let ``deserialize InternalTag NamedFields with JsonName`` () =
+        Assert.Equal(
+            JNs 1,
+            JsonSerializer.Deserialize("""{"Case":"jstring","jnsField":1}""", internalTagNamedFieldsOptions)
+        )
+        Assert.Equal(JNi 1, JsonSerializer.Deserialize("""{"Case":42,"jniField":1}""", internalTagNamedFieldsOptions))
+        Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"Case":true,"jnbField":1}""", internalTagNamedFieldsOptions))
+        Assert.Equal(
+            JNn 1,
+            JsonSerializer.Deserialize("""{"Case":"JNn","jnnField":1}""", internalTagNamedFieldsOptions)
+        )
+
+    [<Fact>]
+    let ``serialize InternalTag NamedFields with JsonName`` () =
+        Assert.Equal(
+            """{"Case":"jstring","jnsField":1}""",
+            JsonSerializer.Serialize(JNs 1, internalTagNamedFieldsOptions)
+        )
+        Assert.Equal("""{"Case":42,"jniField":1}""", JsonSerializer.Serialize(JNi 1, internalTagNamedFieldsOptions))
+        Assert.Equal("""{"Case":true,"jnbField":1}""", JsonSerializer.Serialize(JNb 1, internalTagNamedFieldsOptions))
+        Assert.Equal("""{"Case":"JNn","jnnField":1}""", JsonSerializer.Serialize(JNn 1, internalTagNamedFieldsOptions))
 
     let internalTagNamedFieldsConfiguredTagOptions = JsonSerializerOptions()
 
@@ -1126,6 +1263,12 @@ module Struct =
         | Bb of int
         | Bc of x: string * bool
 
+    type JN =
+        | [<JsonName "jstring">] JNs of jnsField: int
+        | [<JsonName 42>] JNi of jniField: int
+        | [<JsonName true>] JNb of jnbField: int
+        | JNn of jnnField: int
+
     let options = JsonSerializerOptions()
     options.Converters.Add(JsonFSharpConverter())
 
@@ -1222,6 +1365,20 @@ module Struct =
             JsonSerializer.Serialize(Bc("test", true), tagCaseInsensitiveOptions)
         )
 
+    [<Fact>]
+    let ``deserialize AdjacentTag with JsonName`` () =
+        Assert.Equal(JNs 1, JsonSerializer.Deserialize("""{"Case":"jstring","Fields":[1]}""", options))
+        Assert.Equal(JNi 1, JsonSerializer.Deserialize("""{"Case":42,"Fields":[1]}""", options))
+        Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"Case":true,"Fields":[1]}""", options))
+        Assert.Equal(JNn 1, JsonSerializer.Deserialize("""{"Case":"JNn","Fields":[1]}""", options))
+
+    [<Fact>]
+    let ``serialize AdjacentTag with JsonName`` () =
+        Assert.Equal("""{"Case":"jstring","Fields":[1]}""", JsonSerializer.Serialize(JNs 1, options))
+        Assert.Equal("""{"Case":42,"Fields":[1]}""", JsonSerializer.Serialize(JNi 1, options))
+        Assert.Equal("""{"Case":true,"Fields":[1]}""", JsonSerializer.Serialize(JNb 1, options))
+        Assert.Equal("""{"Case":"JNn","Fields":[1]}""", JsonSerializer.Serialize(JNn 1, options))
+
     let externalTagOptions = JsonSerializerOptions()
     externalTagOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.ExternalTag))
 
@@ -1254,6 +1411,20 @@ module Struct =
         Assert.Equal("""{"ba":[]}""", JsonSerializer.Serialize(Ba, externalTagPolicyOptions))
         Assert.Equal("""{"bb":[32]}""", JsonSerializer.Serialize(Bb 32, externalTagPolicyOptions))
         Assert.Equal("""{"bc":["test",true]}""", JsonSerializer.Serialize(Bc("test", true), externalTagPolicyOptions))
+
+    [<Fact>]
+    let ``deserialize ExternalTag with JsonName`` () =
+        Assert.Equal(JNs 1, JsonSerializer.Deserialize("""{"jstring":[1]}""", externalTagOptions))
+        Assert.Equal(JNi 1, JsonSerializer.Deserialize("""{"42":[1]}""", externalTagOptions))
+        Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"true":[1]}""", externalTagOptions))
+        Assert.Equal(JNn 1, JsonSerializer.Deserialize("""{"JNn":[1]}""", externalTagOptions))
+
+    [<Fact>]
+    let ``serialize ExternalTag with JsonName`` () =
+        Assert.Equal("""{"jstring":[1]}""", JsonSerializer.Serialize(JNs 1, externalTagOptions))
+        Assert.Equal("""{"42":[1]}""", JsonSerializer.Serialize(JNi 1, externalTagOptions))
+        Assert.Equal("""{"true":[1]}""", JsonSerializer.Serialize(JNb 1, externalTagOptions))
+        Assert.Equal("""{"JNn":[1]}""", JsonSerializer.Serialize(JNn 1, externalTagOptions))
 
     let internalTagOptions = JsonSerializerOptions()
     internalTagOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.InternalTag))
@@ -1288,6 +1459,20 @@ module Struct =
         Assert.Equal("""["bb",32]""", JsonSerializer.Serialize(Bb 32, internalTagPolicyOptions))
         Assert.Equal("""["bc","test",true]""", JsonSerializer.Serialize(Bc("test", true), internalTagPolicyOptions))
 
+    [<Fact>]
+    let ``deserialize InternalTag with JsonName`` () =
+        Assert.Equal(JNs 1, JsonSerializer.Deserialize("""["jstring",1]""", internalTagOptions))
+        Assert.Equal(JNi 1, JsonSerializer.Deserialize("""[42,1]""", internalTagOptions))
+        Assert.Equal(JNb 1, JsonSerializer.Deserialize("""[true,1]""", internalTagOptions))
+        Assert.Equal(JNn 1, JsonSerializer.Deserialize("""["JNn",1]""", internalTagOptions))
+
+    [<Fact>]
+    let ``serialize InternalTag with JsonName`` () =
+        Assert.Equal("""["jstring",1]""", JsonSerializer.Serialize(JNs 1, internalTagOptions))
+        Assert.Equal("""[42,1]""", JsonSerializer.Serialize(JNi 1, internalTagOptions))
+        Assert.Equal("""[true,1]""", JsonSerializer.Serialize(JNb 1, internalTagOptions))
+        Assert.Equal("""["JNn",1]""", JsonSerializer.Serialize(JNn 1, internalTagOptions))
+
     let untaggedOptions = JsonSerializerOptions()
     untaggedOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.Untagged))
 
@@ -1302,6 +1487,20 @@ module Struct =
         Assert.Equal("""{}""", JsonSerializer.Serialize(Ba, untaggedOptions))
         Assert.Equal("""{"Item":32}""", JsonSerializer.Serialize(Bb 32, untaggedOptions))
         Assert.Equal("""{"x":"test","Item2":true}""", JsonSerializer.Serialize(Bc("test", true), untaggedOptions))
+
+    [<Fact>]
+    let ``deserialize Untagged with JsonName`` () =
+        Assert.Equal(JNs 1, JsonSerializer.Deserialize("""{"jnsField":1}""", untaggedOptions))
+        Assert.Equal(JNi 1, JsonSerializer.Deserialize("""{"jniField":1}""", untaggedOptions))
+        Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"jnbField":1}""", untaggedOptions))
+        Assert.Equal(JNn 1, JsonSerializer.Deserialize("""{"jnnField":1}""", untaggedOptions))
+
+    [<Fact>]
+    let ``serialize Untagged with JsonName`` () =
+        Assert.Equal("""{"jnsField":1}""", JsonSerializer.Serialize(JNs 1, untaggedOptions))
+        Assert.Equal("""{"jniField":1}""", JsonSerializer.Serialize(JNi 1, untaggedOptions))
+        Assert.Equal("""{"jnbField":1}""", JsonSerializer.Serialize(JNb 1, untaggedOptions))
+        Assert.Equal("""{"jnnField":1}""", JsonSerializer.Serialize(JNn 1, untaggedOptions))
 
     let adjacentTagNamedFieldsOptions = JsonSerializerOptions()
 
@@ -1392,6 +1591,44 @@ module Struct =
             JsonSerializer.Serialize(Bc("test", true), adjacentTagNamedFieldsTagPolicyOptions)
         )
 
+    [<Fact>]
+    let ``deserialize AdjacentTag NamedFields with JsonName`` () =
+        Assert.Equal(
+            JNs 1,
+            JsonSerializer.Deserialize("""{"Case":"jstring","Fields":{"jnsField":1}}""", adjacentTagNamedFieldsOptions)
+        )
+        Assert.Equal(
+            JNi 1,
+            JsonSerializer.Deserialize("""{"Case":42,"Fields":{"jniField":1}}""", adjacentTagNamedFieldsOptions)
+        )
+        Assert.Equal(
+            JNb 1,
+            JsonSerializer.Deserialize("""{"Case":true,"Fields":{"jnbField":1}}""", adjacentTagNamedFieldsOptions)
+        )
+        Assert.Equal(
+            JNn 1,
+            JsonSerializer.Deserialize("""{"Case":"JNn","Fields":{"jnnField":1}}""", adjacentTagNamedFieldsOptions)
+        )
+
+    [<Fact>]
+    let ``serialize AdjacentTag NamedFields with JsonName`` () =
+        Assert.Equal(
+            """{"Case":"jstring","Fields":{"jnsField":1}}""",
+            JsonSerializer.Serialize(JNs 1, adjacentTagNamedFieldsOptions)
+        )
+        Assert.Equal(
+            """{"Case":42,"Fields":{"jniField":1}}""",
+            JsonSerializer.Serialize(JNi 1, adjacentTagNamedFieldsOptions)
+        )
+        Assert.Equal(
+            """{"Case":true,"Fields":{"jnbField":1}}""",
+            JsonSerializer.Serialize(JNb 1, adjacentTagNamedFieldsOptions)
+        )
+        Assert.Equal(
+            """{"Case":"JNn","Fields":{"jnnField":1}}""",
+            JsonSerializer.Serialize(JNn 1, adjacentTagNamedFieldsOptions)
+        )
+
     let externalTagNamedFieldsOptions = JsonSerializerOptions()
 
     externalTagNamedFieldsOptions.Converters.Add(
@@ -1445,6 +1682,20 @@ module Struct =
             """{"bc":{"x":"test","Item2":true}}""",
             JsonSerializer.Serialize(Bc("test", true), externalTagNamedFieldsTagPolicyOptions)
         )
+
+    [<Fact>]
+    let ``deserialize ExternalTag NamedFields with JsonName`` () =
+        Assert.Equal(JNs 1, JsonSerializer.Deserialize("""{"jstring":{"jnsField":1}}""", externalTagNamedFieldsOptions))
+        Assert.Equal(JNi 1, JsonSerializer.Deserialize("""{"42":{"jniField":1}}""", externalTagNamedFieldsOptions))
+        Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"true":{"jnbField":1}}""", externalTagNamedFieldsOptions))
+        Assert.Equal(JNn 1, JsonSerializer.Deserialize("""{"JNn":{"jnnField":1}}""", externalTagNamedFieldsOptions))
+
+    [<Fact>]
+    let ``serialize ExternalTag NamedFields with JsonName`` () =
+        Assert.Equal("""{"jstring":{"jnsField":1}}""", JsonSerializer.Serialize(JNs 1, externalTagNamedFieldsOptions))
+        Assert.Equal("""{"42":{"jniField":1}}""", JsonSerializer.Serialize(JNi 1, externalTagNamedFieldsOptions))
+        Assert.Equal("""{"true":{"jnbField":1}}""", JsonSerializer.Serialize(JNb 1, externalTagNamedFieldsOptions))
+        Assert.Equal("""{"JNn":{"jnnField":1}}""", JsonSerializer.Serialize(JNn 1, externalTagNamedFieldsOptions))
 
     let internalTagNamedFieldsOptions = JsonSerializerOptions()
 
@@ -1562,6 +1813,29 @@ module Struct =
             """{"Case":"bc","x":"test","Item2":true}""",
             JsonSerializer.Serialize(Bc("test", true), internalTagNamedFieldsTagPolicyOptions)
         )
+
+    [<Fact>]
+    let ``deserialize InternalTag NamedFields with JsonName`` () =
+        Assert.Equal(
+            JNs 1,
+            JsonSerializer.Deserialize("""{"Case":"jstring","jnsField":1}""", internalTagNamedFieldsOptions)
+        )
+        Assert.Equal(JNi 1, JsonSerializer.Deserialize("""{"Case":42,"jniField":1}""", internalTagNamedFieldsOptions))
+        Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"Case":true,"jnbField":1}""", internalTagNamedFieldsOptions))
+        Assert.Equal(
+            JNn 1,
+            JsonSerializer.Deserialize("""{"Case":"JNn","jnnField":1}""", internalTagNamedFieldsOptions)
+        )
+
+    [<Fact>]
+    let ``serialize InternalTag NamedFields with JsonName`` () =
+        Assert.Equal(
+            """{"Case":"jstring","jnsField":1}""",
+            JsonSerializer.Serialize(JNs 1, internalTagNamedFieldsOptions)
+        )
+        Assert.Equal("""{"Case":42,"jniField":1}""", JsonSerializer.Serialize(JNi 1, internalTagNamedFieldsOptions))
+        Assert.Equal("""{"Case":true,"jnbField":1}""", JsonSerializer.Serialize(JNb 1, internalTagNamedFieldsOptions))
+        Assert.Equal("""{"Case":"JNn","jnnField":1}""", JsonSerializer.Serialize(JNn 1, internalTagNamedFieldsOptions))
 
     let internalTagNamedFieldsConfiguredTagOptions = JsonSerializerOptions()
 

--- a/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
@@ -33,7 +33,7 @@ module NonStruct =
     type JN =
         | [<JsonName "jstring">] JNs of jnsField: int
         | [<JsonName 42>] JNi of jniField: int
-        | [<JsonName true; JsonName "jbool">] JNb of jnbField: int
+        | [<JsonName(true, "jbool")>] JNb of jnbField: int
         | JNn of jnnField: int
 
     let options = JsonSerializerOptions()
@@ -1278,7 +1278,7 @@ module Struct =
     type JN =
         | [<JsonName "jstring">] JNs of jnsField: int
         | [<JsonName 42>] JNi of jniField: int
-        | [<JsonName true; JsonName "jbool">] JNb of jnbField: int
+        | [<JsonName(true, "jbool")>] JNb of jnbField: int
         | JNn of jnnField: int
 
     let options = JsonSerializerOptions()

--- a/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
@@ -31,7 +31,7 @@ module NonStruct =
         | Bc of x: string * bool
 
     type JN =
-        | [<JsonName "jstring">] JNs of jnsField: int
+        | [<JsonName "jstring"; JsonName("a", "b", Field = "jnsField2")>] JNs of jnsField: int * jnsField2: int
         | [<JsonName 42>] JNi of jniField: int
         | [<JsonName(true, "jbool")>] JNb of jnbField: int
         | JNn of jnnField: int
@@ -121,7 +121,7 @@ module NonStruct =
 
     [<Fact>]
     let ``deserialize AdjacentTag with JsonName`` () =
-        Assert.Equal(JNs 1, JsonSerializer.Deserialize("""{"Case":"jstring","Fields":[1]}""", options))
+        Assert.Equal(JNs(1, 2), JsonSerializer.Deserialize("""{"Case":"jstring","Fields":[1,2]}""", options))
         Assert.Equal(JNi 1, JsonSerializer.Deserialize("""{"Case":42,"Fields":[1]}""", options))
         Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"Case":true,"Fields":[1]}""", options))
         Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"Case":"jbool","Fields":[1]}""", options))
@@ -129,7 +129,7 @@ module NonStruct =
 
     [<Fact>]
     let ``serialize AdjacentTag with JsonName`` () =
-        Assert.Equal("""{"Case":"jstring","Fields":[1]}""", JsonSerializer.Serialize(JNs 1, options))
+        Assert.Equal("""{"Case":"jstring","Fields":[1,2]}""", JsonSerializer.Serialize(JNs(1, 2), options))
         Assert.Equal("""{"Case":42,"Fields":[1]}""", JsonSerializer.Serialize(JNi 1, options))
         Assert.Equal("""{"Case":true,"Fields":[1]}""", JsonSerializer.Serialize(JNb 1, options))
         Assert.Equal("""{"Case":"JNn","Fields":[1]}""", JsonSerializer.Serialize(JNn 1, options))
@@ -185,7 +185,7 @@ module NonStruct =
 
     [<Fact>]
     let ``deserialize ExternalTag with JsonName`` () =
-        Assert.Equal(JNs 1, JsonSerializer.Deserialize("""{"jstring":[1]}""", externalTagOptions))
+        Assert.Equal(JNs(1, 2), JsonSerializer.Deserialize("""{"jstring":[1,2]}""", externalTagOptions))
         Assert.Equal(JNi 1, JsonSerializer.Deserialize("""{"42":[1]}""", externalTagOptions))
         Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"true":[1]}""", externalTagOptions))
         Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"jbool":[1]}""", externalTagOptions))
@@ -193,7 +193,7 @@ module NonStruct =
 
     [<Fact>]
     let ``serialize ExternalTag with JsonName`` () =
-        Assert.Equal("""{"jstring":[1]}""", JsonSerializer.Serialize(JNs 1, externalTagOptions))
+        Assert.Equal("""{"jstring":[1,2]}""", JsonSerializer.Serialize(JNs(1, 2), externalTagOptions))
         Assert.Equal("""{"42":[1]}""", JsonSerializer.Serialize(JNi 1, externalTagOptions))
         Assert.Equal("""{"true":[1]}""", JsonSerializer.Serialize(JNb 1, externalTagOptions))
         Assert.Equal("""{"JNn":[1]}""", JsonSerializer.Serialize(JNn 1, externalTagOptions))
@@ -233,7 +233,7 @@ module NonStruct =
 
     [<Fact>]
     let ``deserialize InternalTag with JsonName`` () =
-        Assert.Equal(JNs 1, JsonSerializer.Deserialize("""["jstring",1]""", internalTagOptions))
+        Assert.Equal(JNs(1, 2), JsonSerializer.Deserialize("""["jstring",1,2]""", internalTagOptions))
         Assert.Equal(JNi 1, JsonSerializer.Deserialize("""[42,1]""", internalTagOptions))
         Assert.Equal(JNb 1, JsonSerializer.Deserialize("""[true,1]""", internalTagOptions))
         Assert.Equal(JNb 1, JsonSerializer.Deserialize("""["jbool",1]""", internalTagOptions))
@@ -241,7 +241,7 @@ module NonStruct =
 
     [<Fact>]
     let ``serialize InternalTag with JsonName`` () =
-        Assert.Equal("""["jstring",1]""", JsonSerializer.Serialize(JNs 1, internalTagOptions))
+        Assert.Equal("""["jstring",1,2]""", JsonSerializer.Serialize(JNs(1, 2), internalTagOptions))
         Assert.Equal("""[42,1]""", JsonSerializer.Serialize(JNi 1, internalTagOptions))
         Assert.Equal("""[true,1]""", JsonSerializer.Serialize(JNb 1, internalTagOptions))
         Assert.Equal("""["JNn",1]""", JsonSerializer.Serialize(JNn 1, internalTagOptions))
@@ -263,14 +263,14 @@ module NonStruct =
 
     [<Fact>]
     let ``deserialize Untagged with JsonName`` () =
-        Assert.Equal(JNs 1, JsonSerializer.Deserialize("""{"jnsField":1}""", untaggedOptions))
+        Assert.Equal(JNs(1, 2), JsonSerializer.Deserialize("""{"jnsField":1,"a":2}""", untaggedOptions))
         Assert.Equal(JNi 1, JsonSerializer.Deserialize("""{"jniField":1}""", untaggedOptions))
         Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"jnbField":1}""", untaggedOptions))
         Assert.Equal(JNn 1, JsonSerializer.Deserialize("""{"jnnField":1}""", untaggedOptions))
 
     [<Fact>]
     let ``serialize Untagged with JsonName`` () =
-        Assert.Equal("""{"jnsField":1}""", JsonSerializer.Serialize(JNs 1, untaggedOptions))
+        Assert.Equal("""{"jnsField":1,"a":2}""", JsonSerializer.Serialize(JNs(1, 2), untaggedOptions))
         Assert.Equal("""{"jniField":1}""", JsonSerializer.Serialize(JNi 1, untaggedOptions))
         Assert.Equal("""{"jnbField":1}""", JsonSerializer.Serialize(JNb 1, untaggedOptions))
         Assert.Equal("""{"jnnField":1}""", JsonSerializer.Serialize(JNn 1, untaggedOptions))
@@ -367,8 +367,18 @@ module NonStruct =
     [<Fact>]
     let ``deserialize AdjacentTag NamedFields with JsonName`` () =
         Assert.Equal(
-            JNs 1,
-            JsonSerializer.Deserialize("""{"Case":"jstring","Fields":{"jnsField":1}}""", adjacentTagNamedFieldsOptions)
+            JNs(1, 2),
+            JsonSerializer.Deserialize(
+                """{"Case":"jstring","Fields":{"jnsField":1,"a":2}}""",
+                adjacentTagNamedFieldsOptions
+            )
+        )
+        Assert.Equal(
+            JNs(1, 2),
+            JsonSerializer.Deserialize(
+                """{"Case":"jstring","Fields":{"jnsField":1,"b":2}}""",
+                adjacentTagNamedFieldsOptions
+            )
         )
         Assert.Equal(
             JNi 1,
@@ -390,8 +400,8 @@ module NonStruct =
     [<Fact>]
     let ``serialize AdjacentTag NamedFields with JsonName`` () =
         Assert.Equal(
-            """{"Case":"jstring","Fields":{"jnsField":1}}""",
-            JsonSerializer.Serialize(JNs 1, adjacentTagNamedFieldsOptions)
+            """{"Case":"jstring","Fields":{"jnsField":1,"a":2}}""",
+            JsonSerializer.Serialize(JNs(1, 2), adjacentTagNamedFieldsOptions)
         )
         Assert.Equal(
             """{"Case":42,"Fields":{"jniField":1}}""",
@@ -462,7 +472,14 @@ module NonStruct =
 
     [<Fact>]
     let ``deserialize ExternalTag NamedFields with JsonName`` () =
-        Assert.Equal(JNs 1, JsonSerializer.Deserialize("""{"jstring":{"jnsField":1}}""", externalTagNamedFieldsOptions))
+        Assert.Equal(
+            JNs(1, 2),
+            JsonSerializer.Deserialize("""{"jstring":{"jnsField":1,"a":2}}""", externalTagNamedFieldsOptions)
+        )
+        Assert.Equal(
+            JNs(1, 2),
+            JsonSerializer.Deserialize("""{"jstring":{"jnsField":1,"b":2}}""", externalTagNamedFieldsOptions)
+        )
         Assert.Equal(JNi 1, JsonSerializer.Deserialize("""{"42":{"jniField":1}}""", externalTagNamedFieldsOptions))
         Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"true":{"jnbField":1}}""", externalTagNamedFieldsOptions))
         Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"jbool":{"jnbField":1}}""", externalTagNamedFieldsOptions))
@@ -470,7 +487,10 @@ module NonStruct =
 
     [<Fact>]
     let ``serialize ExternalTag NamedFields with JsonName`` () =
-        Assert.Equal("""{"jstring":{"jnsField":1}}""", JsonSerializer.Serialize(JNs 1, externalTagNamedFieldsOptions))
+        Assert.Equal(
+            """{"jstring":{"jnsField":1,"a":2}}""",
+            JsonSerializer.Serialize(JNs(1, 2), externalTagNamedFieldsOptions)
+        )
         Assert.Equal("""{"42":{"jniField":1}}""", JsonSerializer.Serialize(JNi 1, externalTagNamedFieldsOptions))
         Assert.Equal("""{"true":{"jnbField":1}}""", JsonSerializer.Serialize(JNb 1, externalTagNamedFieldsOptions))
         Assert.Equal("""{"JNn":{"jnnField":1}}""", JsonSerializer.Serialize(JNn 1, externalTagNamedFieldsOptions))
@@ -594,8 +614,12 @@ module NonStruct =
     [<Fact>]
     let ``deserialize InternalTag NamedFields with JsonName`` () =
         Assert.Equal(
-            JNs 1,
-            JsonSerializer.Deserialize("""{"Case":"jstring","jnsField":1}""", internalTagNamedFieldsOptions)
+            JNs(1, 2),
+            JsonSerializer.Deserialize("""{"Case":"jstring","jnsField":1,"a":2}""", internalTagNamedFieldsOptions)
+        )
+        Assert.Equal(
+            JNs(1, 2),
+            JsonSerializer.Deserialize("""{"Case":"jstring","jnsField":1,"b":2}""", internalTagNamedFieldsOptions)
         )
         Assert.Equal(JNi 1, JsonSerializer.Deserialize("""{"Case":42,"jniField":1}""", internalTagNamedFieldsOptions))
         Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"Case":true,"jnbField":1}""", internalTagNamedFieldsOptions))
@@ -611,8 +635,8 @@ module NonStruct =
     [<Fact>]
     let ``serialize InternalTag NamedFields with JsonName`` () =
         Assert.Equal(
-            """{"Case":"jstring","jnsField":1}""",
-            JsonSerializer.Serialize(JNs 1, internalTagNamedFieldsOptions)
+            """{"Case":"jstring","jnsField":1,"a":2}""",
+            JsonSerializer.Serialize(JNs(1, 2), internalTagNamedFieldsOptions)
         )
         Assert.Equal("""{"Case":42,"jniField":1}""", JsonSerializer.Serialize(JNi 1, internalTagNamedFieldsOptions))
         Assert.Equal("""{"Case":true,"jnbField":1}""", JsonSerializer.Serialize(JNb 1, internalTagNamedFieldsOptions))
@@ -1276,7 +1300,7 @@ module Struct =
         | Bc of x: string * bool
 
     type JN =
-        | [<JsonName "jstring">] JNs of jnsField: int
+        | [<JsonName "jstring"; JsonName("a", "b", Field = "jnsField2")>] JNs of jnsField: int * jnsField2: int
         | [<JsonName 42>] JNi of jniField: int
         | [<JsonName(true, "jbool")>] JNb of jnbField: int
         | JNn of jnnField: int
@@ -1379,7 +1403,7 @@ module Struct =
 
     [<Fact>]
     let ``deserialize AdjacentTag with JsonName`` () =
-        Assert.Equal(JNs 1, JsonSerializer.Deserialize("""{"Case":"jstring","Fields":[1]}""", options))
+        Assert.Equal(JNs(1, 2), JsonSerializer.Deserialize("""{"Case":"jstring","Fields":[1,2]}""", options))
         Assert.Equal(JNi 1, JsonSerializer.Deserialize("""{"Case":42,"Fields":[1]}""", options))
         Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"Case":true,"Fields":[1]}""", options))
         Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"Case":"jbool","Fields":[1]}""", options))
@@ -1387,7 +1411,7 @@ module Struct =
 
     [<Fact>]
     let ``serialize AdjacentTag with JsonName`` () =
-        Assert.Equal("""{"Case":"jstring","Fields":[1]}""", JsonSerializer.Serialize(JNs 1, options))
+        Assert.Equal("""{"Case":"jstring","Fields":[1,2]}""", JsonSerializer.Serialize(JNs(1, 2), options))
         Assert.Equal("""{"Case":42,"Fields":[1]}""", JsonSerializer.Serialize(JNi 1, options))
         Assert.Equal("""{"Case":true,"Fields":[1]}""", JsonSerializer.Serialize(JNb 1, options))
         Assert.Equal("""{"Case":"JNn","Fields":[1]}""", JsonSerializer.Serialize(JNn 1, options))
@@ -1427,7 +1451,7 @@ module Struct =
 
     [<Fact>]
     let ``deserialize ExternalTag with JsonName`` () =
-        Assert.Equal(JNs 1, JsonSerializer.Deserialize("""{"jstring":[1]}""", externalTagOptions))
+        Assert.Equal(JNs(1, 2), JsonSerializer.Deserialize("""{"jstring":[1,2]}""", externalTagOptions))
         Assert.Equal(JNi 1, JsonSerializer.Deserialize("""{"42":[1]}""", externalTagOptions))
         Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"true":[1]}""", externalTagOptions))
         Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"jbool":[1]}""", externalTagOptions))
@@ -1435,7 +1459,7 @@ module Struct =
 
     [<Fact>]
     let ``serialize ExternalTag with JsonName`` () =
-        Assert.Equal("""{"jstring":[1]}""", JsonSerializer.Serialize(JNs 1, externalTagOptions))
+        Assert.Equal("""{"jstring":[1,2]}""", JsonSerializer.Serialize(JNs(1, 2), externalTagOptions))
         Assert.Equal("""{"42":[1]}""", JsonSerializer.Serialize(JNi 1, externalTagOptions))
         Assert.Equal("""{"true":[1]}""", JsonSerializer.Serialize(JNb 1, externalTagOptions))
         Assert.Equal("""{"JNn":[1]}""", JsonSerializer.Serialize(JNn 1, externalTagOptions))
@@ -1475,7 +1499,7 @@ module Struct =
 
     [<Fact>]
     let ``deserialize InternalTag with JsonName`` () =
-        Assert.Equal(JNs 1, JsonSerializer.Deserialize("""["jstring",1]""", internalTagOptions))
+        Assert.Equal(JNs(1, 2), JsonSerializer.Deserialize("""["jstring",1,2]""", internalTagOptions))
         Assert.Equal(JNi 1, JsonSerializer.Deserialize("""[42,1]""", internalTagOptions))
         Assert.Equal(JNb 1, JsonSerializer.Deserialize("""[true,1]""", internalTagOptions))
         Assert.Equal(JNb 1, JsonSerializer.Deserialize("""["jbool",1]""", internalTagOptions))
@@ -1483,7 +1507,7 @@ module Struct =
 
     [<Fact>]
     let ``serialize InternalTag with JsonName`` () =
-        Assert.Equal("""["jstring",1]""", JsonSerializer.Serialize(JNs 1, internalTagOptions))
+        Assert.Equal("""["jstring",1,2]""", JsonSerializer.Serialize(JNs(1, 2), internalTagOptions))
         Assert.Equal("""[42,1]""", JsonSerializer.Serialize(JNi 1, internalTagOptions))
         Assert.Equal("""[true,1]""", JsonSerializer.Serialize(JNb 1, internalTagOptions))
         Assert.Equal("""["JNn",1]""", JsonSerializer.Serialize(JNn 1, internalTagOptions))
@@ -1505,14 +1529,15 @@ module Struct =
 
     [<Fact>]
     let ``deserialize Untagged with JsonName`` () =
-        Assert.Equal(JNs 1, JsonSerializer.Deserialize("""{"jnsField":1}""", untaggedOptions))
+        Assert.Equal(JNs(1, 2), JsonSerializer.Deserialize("""{"jnsField":1,"a":2}""", untaggedOptions))
+        Assert.Equal(JNs(1, 2), JsonSerializer.Deserialize("""{"jnsField":1,"b":2}""", untaggedOptions))
         Assert.Equal(JNi 1, JsonSerializer.Deserialize("""{"jniField":1}""", untaggedOptions))
         Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"jnbField":1}""", untaggedOptions))
         Assert.Equal(JNn 1, JsonSerializer.Deserialize("""{"jnnField":1}""", untaggedOptions))
 
     [<Fact>]
     let ``serialize Untagged with JsonName`` () =
-        Assert.Equal("""{"jnsField":1}""", JsonSerializer.Serialize(JNs 1, untaggedOptions))
+        Assert.Equal("""{"jnsField":1,"a":2}""", JsonSerializer.Serialize(JNs(1, 2), untaggedOptions))
         Assert.Equal("""{"jniField":1}""", JsonSerializer.Serialize(JNi 1, untaggedOptions))
         Assert.Equal("""{"jnbField":1}""", JsonSerializer.Serialize(JNb 1, untaggedOptions))
         Assert.Equal("""{"jnnField":1}""", JsonSerializer.Serialize(JNn 1, untaggedOptions))
@@ -1609,8 +1634,18 @@ module Struct =
     [<Fact>]
     let ``deserialize AdjacentTag NamedFields with JsonName`` () =
         Assert.Equal(
-            JNs 1,
-            JsonSerializer.Deserialize("""{"Case":"jstring","Fields":{"jnsField":1}}""", adjacentTagNamedFieldsOptions)
+            JNs(1, 2),
+            JsonSerializer.Deserialize(
+                """{"Case":"jstring","Fields":{"jnsField":1,"a":2}}""",
+                adjacentTagNamedFieldsOptions
+            )
+        )
+        Assert.Equal(
+            JNs(1, 2),
+            JsonSerializer.Deserialize(
+                """{"Case":"jstring","Fields":{"jnsField":1,"b":2}}""",
+                adjacentTagNamedFieldsOptions
+            )
         )
         Assert.Equal(
             JNi 1,
@@ -1632,8 +1667,8 @@ module Struct =
     [<Fact>]
     let ``serialize AdjacentTag NamedFields with JsonName`` () =
         Assert.Equal(
-            """{"Case":"jstring","Fields":{"jnsField":1}}""",
-            JsonSerializer.Serialize(JNs 1, adjacentTagNamedFieldsOptions)
+            """{"Case":"jstring","Fields":{"jnsField":1,"a":2}}""",
+            JsonSerializer.Serialize(JNs(1, 2), adjacentTagNamedFieldsOptions)
         )
         Assert.Equal(
             """{"Case":42,"Fields":{"jniField":1}}""",
@@ -1704,7 +1739,14 @@ module Struct =
 
     [<Fact>]
     let ``deserialize ExternalTag NamedFields with JsonName`` () =
-        Assert.Equal(JNs 1, JsonSerializer.Deserialize("""{"jstring":{"jnsField":1}}""", externalTagNamedFieldsOptions))
+        Assert.Equal(
+            JNs(1, 2),
+            JsonSerializer.Deserialize("""{"jstring":{"jnsField":1,"a":2}}""", externalTagNamedFieldsOptions)
+        )
+        Assert.Equal(
+            JNs(1, 2),
+            JsonSerializer.Deserialize("""{"jstring":{"jnsField":1,"b":2}}""", externalTagNamedFieldsOptions)
+        )
         Assert.Equal(JNi 1, JsonSerializer.Deserialize("""{"42":{"jniField":1}}""", externalTagNamedFieldsOptions))
         Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"true":{"jnbField":1}}""", externalTagNamedFieldsOptions))
         Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"jbool":{"jnbField":1}}""", externalTagNamedFieldsOptions))
@@ -1712,7 +1754,10 @@ module Struct =
 
     [<Fact>]
     let ``serialize ExternalTag NamedFields with JsonName`` () =
-        Assert.Equal("""{"jstring":{"jnsField":1}}""", JsonSerializer.Serialize(JNs 1, externalTagNamedFieldsOptions))
+        Assert.Equal(
+            """{"jstring":{"jnsField":1,"a":2}}""",
+            JsonSerializer.Serialize(JNs(1, 2), externalTagNamedFieldsOptions)
+        )
         Assert.Equal("""{"42":{"jniField":1}}""", JsonSerializer.Serialize(JNi 1, externalTagNamedFieldsOptions))
         Assert.Equal("""{"true":{"jnbField":1}}""", JsonSerializer.Serialize(JNb 1, externalTagNamedFieldsOptions))
         Assert.Equal("""{"JNn":{"jnnField":1}}""", JsonSerializer.Serialize(JNn 1, externalTagNamedFieldsOptions))
@@ -1837,8 +1882,12 @@ module Struct =
     [<Fact>]
     let ``deserialize InternalTag NamedFields with JsonName`` () =
         Assert.Equal(
-            JNs 1,
-            JsonSerializer.Deserialize("""{"Case":"jstring","jnsField":1}""", internalTagNamedFieldsOptions)
+            JNs(1, 2),
+            JsonSerializer.Deserialize("""{"Case":"jstring","jnsField":1,"a":2}""", internalTagNamedFieldsOptions)
+        )
+        Assert.Equal(
+            JNs(1, 2),
+            JsonSerializer.Deserialize("""{"Case":"jstring","jnsField":1,"b":2}""", internalTagNamedFieldsOptions)
         )
         Assert.Equal(JNi 1, JsonSerializer.Deserialize("""{"Case":42,"jniField":1}""", internalTagNamedFieldsOptions))
         Assert.Equal(JNb 1, JsonSerializer.Deserialize("""{"Case":true,"jnbField":1}""", internalTagNamedFieldsOptions))
@@ -1854,8 +1903,8 @@ module Struct =
     [<Fact>]
     let ``serialize InternalTag NamedFields with JsonName`` () =
         Assert.Equal(
-            """{"Case":"jstring","jnsField":1}""",
-            JsonSerializer.Serialize(JNs 1, internalTagNamedFieldsOptions)
+            """{"Case":"jstring","jnsField":1,"a":2}""",
+            JsonSerializer.Serialize(JNs(1, 2), internalTagNamedFieldsOptions)
         )
         Assert.Equal("""{"Case":42,"jniField":1}""", JsonSerializer.Serialize(JNi 1, internalTagNamedFieldsOptions))
         Assert.Equal("""{"Case":true,"jnbField":1}""", JsonSerializer.Serialize(JNb 1, internalTagNamedFieldsOptions))


### PR DESCRIPTION
* [x] Create `JsonNameAttribute` which can be constructed with a string, an int or a bool.
* [x] Support `JsonNameAttribute` on union cases to enable int or bool tags.
    ```fsharp
    type MyUnion =
        | [<JsonName 1>] One of name: string
        | [<JsonName 2>] Two of string
    // eg: One "test" --> {"Case":1,"Fields":{"name":"test"}}
    ```
    They are stringified when used as JSON property names (eg with `ExternalTag`: `{"1":["test"]}`).
* [x] Support `JsonNameAttribute` on record properties.
* [x] Support multiple `JsonNameAttribute`s on the same item. The first one is used for serialization, and all can be used for deserialization.
    ```fsharp
    type MyUnion =
        | [<JsonName 1; JsonName "a">] One of string
        | [<JsonName 2>] Two of string
    ```
* [x] Support `JsonNameAttribute` on union cases to specify the name of a union field.
    ```fsharp
    type MyUnion =
        | [<JsonName("name", "theName")>] One of name: string
    // eg: One "test" --> {"Case":"One","Fields":{"theName":"test"}}
    ```
