### PR TITLE
Add fluent options builder

### DIFF
--- a/src/FSharp.SystemTextJson/All.fs
+++ b/src/FSharp.SystemTextJson/All.fs
@@ -82,9 +82,57 @@ type JsonFSharpConverter(fsOptions: JsonFSharpOptions, [<Optional>] overrides: I
         )
 
 [<AttributeUsage(AttributeTargets.Class ||| AttributeTargets.Struct)>]
-type JsonFSharpConverterAttribute
-    (
-        [<Optional; DefaultParameterValue(Default.UnionEncoding ||| JsonUnionEncoding.Inherit)>] unionEncoding: JsonUnionEncoding,
+type JsonFSharpConverterAttribute(fsOptions: JsonFSharpOptions) =
+    inherit JsonConverterAttribute()
+
+    let mutable fsOptions = fsOptions
+
+    static let namingPolicy =
+        function
+        | JsonKnownNamingPolicy.Unspecified -> null
+        | JsonKnownNamingPolicy.CamelCase -> JsonNamingPolicy.CamelCase
+        | p -> failwithf "Unknown naming policy: %A" p
+
+    member _.UnionEncoding
+        with set v = fsOptions <- fsOptions.WithUnionEncoding(v)
+    member _.BaseUnionEncoding
+        with set v = fsOptions <- fsOptions.WithBaseUnionEncoding(v)
+    member _.UnionTagName
+        with set v = fsOptions <- fsOptions.WithUnionTagName(v)
+    member _.UnionFieldsName
+        with set v = fsOptions <- fsOptions.WithUnionFieldsName(v)
+    member _.UnionTagNamingPolicy
+        with set v = fsOptions <- fsOptions.WithUnionTagNamingPolicy(namingPolicy v)
+    member _.UnionFieldNamingPolicy
+        with set v = fsOptions <- fsOptions.WithUnionFieldNamingPolicy(namingPolicy v)
+    member _.UnionTagCaseSensitive
+        with set v = fsOptions <- fsOptions.WithUnionTagCaseInsensitive(v)
+    member _.AllowNullFields
+        with set v = fsOptions <- fsOptions.WithAllowNullFields(v)
+    member _.IncludeRecordProperties
+        with set v = fsOptions <- fsOptions.WithIncludeRecordProperties(v)
+    member _.Types
+        with set v = fsOptions <- fsOptions.WithTypes(v)
+    member _.UnionNamedFields
+        with set v = fsOptions <- fsOptions.WithUnionNamedFields(v)
+    member _.UnionUnwrapFieldlessTags
+        with set v = fsOptions <- fsOptions.WithUnionUnwrapFieldlessTags(v)
+    member _.UnwrapOption
+        with set v = fsOptions <- fsOptions.WithUnwrapOption(v)
+    member _.UnionUnwrapSingleCaseUnions
+        with set v = fsOptions <- fsOptions.WithUnionUnwrapSingleCaseUnions(v)
+    member _.UnionUnwrapSingleFieldCases
+        with set v = fsOptions <- fsOptions.WithUnionUnwrapSingleFieldCases(v)
+    member _.UnionUnwrapRecordCases
+        with set v = fsOptions <- fsOptions.WithUnionUnwrapRecordCases(v)
+    member _.UnionAllowUnorderedTag
+        with set v = fsOptions <- fsOptions.WithUnionAllowUnorderedTag(v)
+    member _.UnionFieldNamesFromTypes
+        with set v = fsOptions <- fsOptions.WithUnionFieldNamesFromTypes(v)
+
+    new() = JsonFSharpConverterAttribute(JsonFSharpOptions())
+
+    new([<Optional; DefaultParameterValue(Default.UnionEncoding ||| JsonUnionEncoding.Inherit)>] unionEncoding: JsonUnionEncoding,
         [<Optional; DefaultParameterValue(Default.UnionTagName)>] unionTagName: JsonUnionTagName,
         [<Optional; DefaultParameterValue(Default.UnionFieldsName)>] unionFieldsName: JsonUnionFieldsName,
         [<Optional; DefaultParameterValue(JsonKnownNamingPolicy.Unspecified)>] unionTagNamingPolicy: JsonKnownNamingPolicy,
@@ -92,33 +140,24 @@ type JsonFSharpConverterAttribute
         [<Optional; DefaultParameterValue(Default.UnionTagCaseInsensitive)>] unionTagCaseInsensitive: bool,
         [<Optional; DefaultParameterValue(Default.AllowNullFields)>] allowNullFields: bool,
         [<Optional; DefaultParameterValue(Default.IncludeRecordProperties)>] includeRecordProperties: bool,
-        [<Optional; DefaultParameterValue(Default.Types)>] types: JsonFSharpTypes
-    ) =
-    inherit JsonConverterAttribute()
-
-    let options = JsonSerializerOptions()
-
-    let namingPolicy =
-        function
-        | JsonKnownNamingPolicy.Unspecified -> null
-        | JsonKnownNamingPolicy.CamelCase -> JsonNamingPolicy.CamelCase
-        | p -> failwithf "Unknown naming policy: %A" p
-
-    let fsOptions =
-        JsonFSharpOptions(
-            unionEncoding = unionEncoding,
-            unionTagName = unionTagName,
-            unionFieldsName = unionFieldsName,
-            unionTagNamingPolicy = namingPolicy unionTagNamingPolicy,
-            unionFieldNamingPolicy = namingPolicy unionFieldNamingPolicy,
-            unionTagCaseInsensitive = unionTagCaseInsensitive,
-            allowNullFields = allowNullFields,
-            includeRecordProperties = includeRecordProperties,
-            types = types,
-            allowOverride = false
-        )
+        [<Optional; DefaultParameterValue(Default.Types)>] types: JsonFSharpTypes) =
+        let fsOptions =
+            JsonFSharpOptions(
+                unionEncoding = unionEncoding,
+                unionTagName = unionTagName,
+                unionFieldsName = unionFieldsName,
+                unionTagNamingPolicy = namingPolicy unionTagNamingPolicy,
+                unionFieldNamingPolicy = namingPolicy unionFieldNamingPolicy,
+                unionTagCaseInsensitive = unionTagCaseInsensitive,
+                allowNullFields = allowNullFields,
+                includeRecordProperties = includeRecordProperties,
+                types = types,
+                allowOverride = false
+            )
+        JsonFSharpConverterAttribute(fsOptions)
 
     override _.CreateConverter(typeToConvert) =
+        let options = JsonSerializerOptions()
         JsonFSharpConverter.CreateConverter(typeToConvert, options, fsOptions)
 
     interface IJsonFSharpConverterAttribute with

--- a/src/FSharp.SystemTextJson/Collection.fs
+++ b/src/FSharp.SystemTextJson/Collection.fs
@@ -5,7 +5,7 @@ open System.Text.Json
 open System.Text.Json.Serialization.Helpers
 open FSharp.Reflection
 
-type JsonListConverter<'T>(fsOptions) =
+type JsonListConverter<'T> internal (fsOptions) =
     inherit JsonConverter<list<'T>>()
     let tType = typeof<'T>
     let tIsNullable = isNullableFieldType fsOptions tType
@@ -21,6 +21,8 @@ type JsonListConverter<'T>(fsOptions) =
 
     override _.Write(writer, value, options) =
         JsonSerializer.Serialize<seq<'T>>(writer, value, options)
+
+    new(fsOptions: JsonFSharpOptions) = JsonListConverter<'T>(fsOptions.Record)
 
 type JsonListConverter(fsOptions) =
     inherit JsonConverterFactory()
@@ -41,7 +43,7 @@ type JsonListConverter(fsOptions) =
     override _.CreateConverter(typeToConvert, _options) =
         JsonListConverter.CreateConverter(typeToConvert, fsOptions)
 
-type JsonSetConverter<'T when 'T: comparison>(fsOptions) =
+type JsonSetConverter<'T when 'T: comparison> internal (fsOptions) =
     inherit JsonConverter<Set<'T>>()
     let tType = typeof<'T>
     let tIsNullable = isNullableFieldType fsOptions tType
@@ -68,6 +70,8 @@ type JsonSetConverter<'T when 'T: comparison>(fsOptions) =
 
     override _.Write(writer, value, options) =
         JsonSerializer.Serialize<seq<'T>>(writer, value, options)
+
+    new(fsOptions: JsonFSharpOptions) = JsonSetConverter<'T>(fsOptions.Record)
 
 type JsonSetConverter(fsOptions) =
     inherit JsonConverterFactory()

--- a/src/FSharp.SystemTextJson/Helpers.fs
+++ b/src/FSharp.SystemTextJson/Helpers.fs
@@ -67,7 +67,7 @@ type Helper =
 
     static member tryGetUnwrappedSingleCaseField
         (
-            fsOptions: JsonFSharpOptions,
+            fsOptions: JsonFSharpOptionsRecord,
             ty: Type,
             cases: UnionCaseInfo[] outref,
             property: PropertyInfo outref
@@ -80,7 +80,7 @@ type Helper =
 /// If null is a valid JSON representation for ty,
 /// then return ValueSome with the value represented by null,
 /// else return ValueNone.
-let rec tryGetNullValue (fsOptions: JsonFSharpOptions) (ty: Type) : obj voption =
+let rec tryGetNullValue (fsOptions: JsonFSharpOptionsRecord) (ty: Type) : obj voption =
     if isNullableUnion ty then
         ValueSome null
     elif ty = typeof<unit> then
@@ -105,10 +105,10 @@ let rec tryGetNullValue (fsOptions: JsonFSharpOptions) (ty: Type) : obj voption 
             |> ValueOption.map (fun x -> FSharpValue.MakeUnion(FSharpType.GetUnionCases(ty, true)[0], [| x |], true))
         | false, _, _ -> ValueNone
 
-let rec isNullableFieldType (fsOptions: JsonFSharpOptions) (ty: Type) =
+let rec isNullableFieldType (fsOptions: JsonFSharpOptionsRecord) (ty: Type) =
     tryGetNullValue fsOptions ty |> ValueOption.isSome
 
-let overrideOptions (ty: Type) (defaultOptions: JsonFSharpOptions) (overrides: IDictionary<Type, JsonFSharpOptions>) =
+let overrideOptions (ty: Type) (defaultOptions: JsonFSharpOptions) =
     let inheritUnionEncoding (options: JsonFSharpOptions) =
         if options.UnionEncoding.HasFlag(JsonUnionEncoding.Inherit) then
             options.WithUnionEncoding(defaultOptions.UnionEncoding)
@@ -126,10 +126,10 @@ let overrideOptions (ty: Type) (defaultOptions: JsonFSharpOptions) (overrides: I
         else
             defaultOptions
 
-    if isNull overrides then
+    if isNull defaultOptions.Overrides then
         applyAttributeOverride ()
     else
-        match overrides.TryGetValue(ty) with
+        match defaultOptions.Overrides.TryGetValue(ty) with
         | true, options -> options |> inheritUnionEncoding
         | false, _ -> applyAttributeOverride ()
 

--- a/src/FSharp.SystemTextJson/Helpers.fs
+++ b/src/FSharp.SystemTextJson/Helpers.fs
@@ -126,10 +126,11 @@ let overrideOptions (ty: Type) (defaultOptions: JsonFSharpOptions) =
         else
             defaultOptions
 
-    if isNull defaultOptions.Overrides then
+    let overrides = defaultOptions.Overrides defaultOptions
+    if isNull overrides then
         applyAttributeOverride ()
     else
-        match defaultOptions.Overrides.TryGetValue(ty) with
+        match overrides.TryGetValue(ty) with
         | true, options -> options |> inheritUnionEncoding
         | false, _ -> applyAttributeOverride ()
 

--- a/src/FSharp.SystemTextJson/Options.fs
+++ b/src/FSharp.SystemTextJson/Options.fs
@@ -276,7 +276,7 @@ and JsonFSharpOptions internal (options: JsonFSharpOptionsRecord) =
         else
             this.WithUnionEncoding(options.UnionEncoding &&& ~~~flag)
 
-    member private this.WithBaseUnionEncoding(flag) =
+    member internal this.WithBaseUnionEncoding(flag) =
         this.WithUnionEncoding(options.UnionEncoding &&& removeBaseEncodings ||| flag)
 
     /// Encode unions as a 2-valued object:

--- a/src/FSharp.SystemTextJson/Options.fs
+++ b/src/FSharp.SystemTextJson/Options.fs
@@ -166,6 +166,9 @@ and JsonFSharpOptions internal (options: JsonFSharpOptionsRecord) =
 
     let removeBaseEncodings = enum<JsonUnionEncoding> ~~~ 0x00_00_00_FF
 
+    static let emptyOverrides (_: JsonFSharpOptions) =
+        null
+
     // Note: For binary compatibility, don't add options to this constructor.
     // New options will only be settable via fluent API.
     new([<Optional; DefaultParameterValue(Default.UnionEncoding ||| JsonUnionEncoding.Inherit)>] unionEncoding: JsonUnionEncoding,
@@ -189,7 +192,7 @@ and JsonFSharpOptions internal (options: JsonFSharpOptionsRecord) =
               IncludeRecordProperties = includeRecordProperties
               Types = types
               AllowOverride = allowOverride
-              Overrides = fun _ -> null }
+              Overrides = emptyOverrides }
         )
 
     static member Default() =
@@ -197,6 +200,15 @@ and JsonFSharpOptions internal (options: JsonFSharpOptionsRecord) =
 
     static member InheritUnionEncoding() =
         JsonFSharpOptions(JsonUnionEncoding.Inherit)
+
+    static member NewtonsoftLike() =
+        JsonFSharpOptions(JsonUnionEncoding.NewtonsoftLike)
+
+    static member ThothLike() =
+        JsonFSharpOptions(JsonUnionEncoding.ThothLike)
+
+    static member FSharpLuLike() =
+        JsonFSharpOptions(JsonUnionEncoding.FSharpLuLike)
 
     member internal _.Record = options
 

--- a/src/FSharp.SystemTextJson/Options.fs
+++ b/src/FSharp.SystemTextJson/Options.fs
@@ -160,7 +160,7 @@ type internal JsonFSharpOptionsRecord =
       IncludeRecordProperties: bool
       Types: JsonFSharpTypes
       AllowOverride: bool
-      Overrides: IDictionary<Type, JsonFSharpOptions> }
+      Overrides: JsonFSharpOptions -> IDictionary<Type, JsonFSharpOptions> }
 
 and JsonFSharpOptions internal (options: JsonFSharpOptionsRecord) =
 
@@ -189,7 +189,7 @@ and JsonFSharpOptions internal (options: JsonFSharpOptionsRecord) =
               IncludeRecordProperties = includeRecordProperties
               Types = types
               AllowOverride = allowOverride
-              Overrides = null }
+              Overrides = fun _ -> null }
         )
 
     static member Default() =
@@ -254,6 +254,9 @@ and JsonFSharpOptions internal (options: JsonFSharpOptionsRecord) =
 
     member _.WithOverrides(overrides) =
         JsonFSharpOptions({ options with Overrides = overrides })
+
+    member _.WithOverrides(overrides) =
+        JsonFSharpOptions({ options with Overrides = fun _ -> overrides })
 
     member private this.WithUnionEncodingFlag(flag, set) =
         if set then

--- a/src/FSharp.SystemTextJson/Options.fs
+++ b/src/FSharp.SystemTextJson/Options.fs
@@ -1,9 +1,11 @@
 namespace System.Text.Json.Serialization
 
 open System
+open System.Collections.Generic
 open System.Runtime.InteropServices
 open System.Text.Json
 
+[<Flags>]
 type JsonUnionEncoding =
 
     //// General base format
@@ -147,9 +149,26 @@ module internal Default =
     [<Literal>]
     let Types = JsonFSharpTypes.All
 
-type JsonFSharpOptions
-    (
-        [<Optional; DefaultParameterValue(Default.UnionEncoding ||| JsonUnionEncoding.Inherit)>] unionEncoding: JsonUnionEncoding,
+type internal JsonFSharpOptionsRecord =
+    { UnionEncoding: JsonUnionEncoding
+      UnionTagName: JsonUnionTagName
+      UnionFieldsName: JsonUnionFieldsName
+      UnionTagNamingPolicy: JsonNamingPolicy
+      UnionFieldNamingPolicy: JsonNamingPolicy
+      UnionTagCaseInsensitive: bool
+      AllowNullFields: bool
+      IncludeRecordProperties: bool
+      Types: JsonFSharpTypes
+      AllowOverride: bool
+      Overrides: IDictionary<Type, JsonFSharpOptions> }
+
+and JsonFSharpOptions internal (options: JsonFSharpOptionsRecord) =
+
+    let removeBaseEncodings = enum<JsonUnionEncoding> ~~~ 0x00_00_00_FF
+
+    // Note: For binary compatibility, don't add options to this constructor.
+    // New options will only be settable via fluent API.
+    new([<Optional; DefaultParameterValue(Default.UnionEncoding ||| JsonUnionEncoding.Inherit)>] unionEncoding: JsonUnionEncoding,
         [<Optional; DefaultParameterValue(Default.UnionTagName)>] unionTagName: JsonUnionTagName,
         [<Optional; DefaultParameterValue(Default.UnionFieldsName)>] unionFieldsName: JsonUnionFieldsName,
         [<Optional; DefaultParameterValue(Default.UnionTagNamingPolicy)>] unionTagNamingPolicy: JsonNamingPolicy,
@@ -158,42 +177,156 @@ type JsonFSharpOptions
         [<Optional; DefaultParameterValue(Default.AllowNullFields)>] allowNullFields: bool,
         [<Optional; DefaultParameterValue(Default.IncludeRecordProperties)>] includeRecordProperties: bool,
         [<Optional; DefaultParameterValue(Default.Types)>] types: JsonFSharpTypes,
-        [<Optional; DefaultParameterValue(false)>] allowOverride: bool
-    ) =
-
-    member this.UnionEncoding = unionEncoding
-
-    member this.UnionTagName = unionTagName
-
-    member this.UnionFieldsName = unionFieldsName
-
-    member this.UnionTagNamingPolicy = unionTagNamingPolicy
-
-    member this.UnionFieldNamingPolicy = unionFieldNamingPolicy
-
-    member this.UnionTagCaseInsensitive = unionTagCaseInsensitive
-
-    member this.AllowNullFields = allowNullFields
-
-    member this.IncludeRecordProperties = includeRecordProperties
-
-    member this.Types = types
-
-    member this.AllowOverride = allowOverride
-
-    member this.WithUnionEncoding(unionEncoding) =
+        [<Optional; DefaultParameterValue(false)>] allowOverride: bool) =
         JsonFSharpOptions(
-            unionEncoding = unionEncoding,
-            unionTagName = unionTagName,
-            unionFieldsName = unionFieldsName,
-            unionTagNamingPolicy = unionTagNamingPolicy,
-            unionFieldNamingPolicy = unionFieldNamingPolicy,
-            unionTagCaseInsensitive = unionTagCaseInsensitive,
-            allowNullFields = allowNullFields,
-            includeRecordProperties = includeRecordProperties,
-            types = types,
-            allowOverride = allowOverride
+            { UnionEncoding = unionEncoding
+              UnionTagName = unionTagName
+              UnionFieldsName = unionFieldsName
+              UnionTagNamingPolicy = unionTagNamingPolicy
+              UnionFieldNamingPolicy = unionFieldNamingPolicy
+              UnionTagCaseInsensitive = unionTagCaseInsensitive
+              AllowNullFields = allowNullFields
+              IncludeRecordProperties = includeRecordProperties
+              Types = types
+              AllowOverride = allowOverride
+              Overrides = null }
         )
+
+    static member Default() =
+        JsonFSharpOptions(Default.UnionEncoding)
+
+    static member InheritUnionEncoding() =
+        JsonFSharpOptions(JsonUnionEncoding.Inherit)
+
+    member internal _.Record = options
+
+    member _.UnionEncoding = options.UnionEncoding
+
+    member _.UnionTagName = options.UnionTagName
+
+    member _.UnionFieldsName = options.UnionFieldsName
+
+    member _.UnionTagNamingPolicy = options.UnionTagNamingPolicy
+
+    member _.UnionFieldNamingPolicy = options.UnionFieldNamingPolicy
+
+    member _.UnionTagCaseInsensitive = options.UnionTagCaseInsensitive
+
+    member _.AllowNullFields = options.AllowNullFields
+
+    member _.IncludeRecordProperties = options.IncludeRecordProperties
+
+    member _.Types = options.Types
+
+    member _.AllowOverride = options.AllowOverride
+
+    member _.Overrides = options.Overrides
+
+    member _.WithUnionEncoding(unionEncoding) =
+        JsonFSharpOptions({ options with UnionEncoding = unionEncoding })
+
+    member _.WithUnionTagName(unionTagName) =
+        JsonFSharpOptions({ options with UnionTagName = unionTagName })
+
+    member _.WithUnionFieldsName(unionFieldsName) =
+        JsonFSharpOptions({ options with UnionFieldsName = unionFieldsName })
+
+    member _.WithUnionTagNamingPolicy(unionTagNamingPolicy) =
+        JsonFSharpOptions({ options with UnionTagNamingPolicy = unionTagNamingPolicy })
+
+    member _.WithUnionFieldNamingPolicy(unionFieldNamingPolicy) =
+        JsonFSharpOptions({ options with UnionFieldNamingPolicy = unionFieldNamingPolicy })
+
+    member _.WithUnionTagCaseInsensitive([<Optional; DefaultParameterValue true>] unionTagCaseInsensitive) =
+        JsonFSharpOptions({ options with UnionTagCaseInsensitive = unionTagCaseInsensitive })
+
+    member _.WithAllowNullFields([<Optional; DefaultParameterValue true>] allowNullFields) =
+        JsonFSharpOptions({ options with AllowNullFields = allowNullFields })
+
+    member _.WithIncludeRecordProperties([<Optional; DefaultParameterValue true>] includeRecordProperties) =
+        JsonFSharpOptions({ options with IncludeRecordProperties = includeRecordProperties })
+
+    member _.WithTypes(types) =
+        JsonFSharpOptions({ options with Types = types })
+
+    member _.WithAllowOverride([<Optional; DefaultParameterValue true>] allowOverride) =
+        JsonFSharpOptions({ options with AllowOverride = allowOverride })
+
+    member _.WithOverrides(overrides) =
+        JsonFSharpOptions({ options with Overrides = overrides })
+
+    member private this.WithUnionEncodingFlag(flag, set) =
+        if set then
+            this.WithUnionEncoding(options.UnionEncoding ||| flag)
+        else
+            this.WithUnionEncoding(options.UnionEncoding &&& ~~~flag)
+
+    member private this.WithBaseUnionEncoding(flag) =
+        this.WithUnionEncoding(options.UnionEncoding &&& removeBaseEncodings ||| flag)
+
+    /// Encode unions as a 2-valued object:
+    /// `unionTagName` (defaults to "Case") contains the union tag,
+    /// and `unionFieldsName` (defaults to "Fields") contains the union fields.
+    /// If the case doesn't have fields, "Fields": [] is omitted.
+    /// This flag is included in Default.
+    member this.WithUnionAdjacentTag() =
+        this.WithBaseUnionEncoding(JsonUnionEncoding.AdjacentTag)
+
+    /// Encode unions as a 1-valued object:
+    /// The field name is the union tag, and the value is the union fields.
+    member this.WithUnionExternalTag() =
+        this.WithBaseUnionEncoding(JsonUnionEncoding.ExternalTag)
+
+    /// Encode unions as a (n+1)-valued object or array (depending on NamedFields):
+    /// the first value (named `unionTagName`, defaulting to "Case", if NamedFields is set)
+    /// is the union tag, the rest are the union fields.
+    member this.WithUnionInternalTag() =
+        this.WithBaseUnionEncoding(JsonUnionEncoding.InternalTag)
+
+    /// Encode unions as a n-valued object:
+    /// the union tag is not encoded, only the union fields are.
+    /// Deserialization is only possible if the fields of all cases have different names.
+    member this.WithUnionUntagged() =
+        this.WithBaseUnionEncoding(JsonUnionEncoding.Untagged)
+
+    /// If unset, union fields are encoded as an array.
+    /// If set, union fields are encoded as an object using their field names.
+    member this.WithUnionNamedFields([<Optional; DefaultParameterValue true>] set: bool) =
+        this.WithUnionEncodingFlag(JsonUnionEncoding.NamedFields, set)
+
+    /// If set, union cases that don't have fields are encoded as a bare string.
+    member this.WithUnionUnwrapFieldlessTags([<Optional; DefaultParameterValue true>] set: bool) =
+        this.WithUnionEncodingFlag(JsonUnionEncoding.UnwrapFieldlessTags, set)
+
+    /// If set, `None` is represented as null,
+    /// and `Some x`  is represented the same as `x`.
+    /// This flag is included in Default.
+    member this.WithUnwrapOption([<Optional; DefaultParameterValue true>] set: bool) =
+        this.WithUnionEncodingFlag(JsonUnionEncoding.UnwrapOption, set)
+
+    /// If set, single-case single-field unions are serialized as the single field's value.
+    /// This flag is included in Default.
+    member this.WithUnionUnwrapSingleCaseUnions([<Optional; DefaultParameterValue true>] set: bool) =
+        this.WithUnionEncodingFlag(JsonUnionEncoding.UnwrapSingleCaseUnions, set)
+
+    /// If set, the field of a single-field union case is encoded as just the value
+    /// rather than a single-value array or object.
+    member this.WithUnionUnwrapSingleFieldCases([<Optional; DefaultParameterValue true>] set: bool) =
+        this.WithUnionEncodingFlag(JsonUnionEncoding.UnwrapSingleFieldCases, set)
+
+    /// Implicitly sets NamedFields. If set, when a union case has a single field which is a record,
+    /// the fields of this record are encoded directly as fields of the object representing the union.
+    member this.WithUnionUnwrapRecordCases([<Optional; DefaultParameterValue true>] set: bool) =
+        this.WithUnionEncodingFlag(JsonUnionEncoding.UnwrapRecordCases, set)
+
+    /// In AdjacentTag and InternalTag mode, allow deserializing unions
+    /// where the tag is not the first field in the JSON object.
+    member this.WithUnionAllowUnorderedTag([<Optional; DefaultParameterValue true>] set: bool) =
+        this.WithUnionEncodingFlag(JsonUnionEncoding.AllowUnorderedTag, set)
+
+    /// When a union field doesn't have an explicit name, use its type as name.
+    member this.WithUnionFieldNamesFromTypes([<Optional; DefaultParameterValue true>] set: bool) =
+        this.WithUnionEncodingFlag(JsonUnionEncoding.UnionFieldNamesFromTypes, set)
 
 type IJsonFSharpConverterAttribute =
     abstract Options: JsonFSharpOptions

--- a/src/FSharp.SystemTextJson/Tuple.fs
+++ b/src/FSharp.SystemTextJson/Tuple.fs
@@ -7,7 +7,7 @@ open FSharp.Reflection
 
 type internal TupleProperty = { Type: Type; NeedsNullChecking: bool }
 
-type JsonTupleConverter<'T>(fsOptions) =
+type JsonTupleConverter<'T> internal (fsOptions) =
     inherit JsonConverter<'T>()
 
     let ty = typeof<'T>
@@ -40,6 +40,8 @@ type JsonTupleConverter<'T>(fsOptions) =
         for i in 0 .. fieldProps.Length - 1 do
             JsonSerializer.Serialize(writer, values[i], fieldProps[i].Type, options)
         writer.WriteEndArray()
+
+    new(fsOptions: JsonFSharpOptions) = JsonTupleConverter<'T>(fsOptions.Record)
 
 type JsonTupleConverter(fsOptions) =
     inherit JsonConverterFactory()

--- a/tests/FSharp.SystemTextJson.Tests/Test.Collection.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Collection.fs
@@ -7,8 +7,7 @@ open Xunit
 open FsCheck
 open FsCheck.Xunit
 
-let options = JsonSerializerOptions()
-options.Converters.Add(JsonFSharpConverter())
+let options = JsonFSharpOptions().ToJsonSerializerOptions()
 
 [<Property>]
 let ``deserialize list of ints`` (l: list<int>) =
@@ -52,8 +51,7 @@ module NullsInsideList =
 
     [<Fact>]
     let ``allow nulls inside array if allowNullFields is true `` () =
-        let options = JsonSerializerOptions()
-        options.Converters.Add(JsonFSharpConverter(allowNullFields = true))
+        let options = JsonFSharpOptions().WithAllowNullFields().ToJsonSerializerOptions()
         let ser = """["hello", null]"""
         let actual = JsonSerializer.Deserialize<string list>(ser, options)
         Assert.Equal<string list>([ "hello"; null ], actual)
@@ -121,9 +119,8 @@ let ``serialize struct-newtype-string-keyed map`` (m: Map<NonNull<string>, int>)
     Assert.Equal(expected, actual)
 
 let keyPolicyOptions =
-    JsonSerializerOptions(DictionaryKeyPolicy = JsonNamingPolicy.CamelCase)
-
-keyPolicyOptions.Converters.Add(JsonFSharpConverter())
+    JsonFSharpOptions()
+        .ToJsonSerializerOptions(DictionaryKeyPolicy = JsonNamingPolicy.CamelCase)
 
 [<Property>]
 let ``deserialize string-keyed map with key policy`` (m: Map<NonNull<string>, int>) =

--- a/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
@@ -21,8 +21,7 @@ module NonStruct =
 
     type B = { bx: int; by: string }
 
-    let options = JsonSerializerOptions()
-    options.Converters.Add(JsonFSharpConverter())
+    let options = JsonFSharpOptions().ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize via options`` () =
@@ -87,8 +86,7 @@ module NonStruct =
 
     [<Fact>]
     let allowNullFields () =
-        let options = JsonSerializerOptions()
-        options.Converters.Add(JsonFSharpConverter(allowNullFields = true))
+        let options = JsonFSharpOptions().WithAllowNullFields().ToJsonSerializerOptions()
         let actual = JsonSerializer.Deserialize("""{"bx":1,"by":null}""", options)
         Assert.Equal({ bx = 1; by = null }, actual)
 
@@ -220,13 +218,12 @@ module NonStruct =
         let actual = JsonSerializer.Serialize({ unignoredX = 1; ignoredY = "b" }, options)
         Assert.Equal("""{"unignoredX":1}""", actual)
 
-    let ignoreNullOptions = JsonSerializerOptions(IgnoreNullValues = true)
-    ignoreNullOptions.Converters.Add(JsonFSharpConverter())
+    let ignoreNullOptions =
+        JsonFSharpOptions().ToJsonSerializerOptions(IgnoreNullValues = true)
 
     let newIgnoreNullOptions =
-        JsonSerializerOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)
-
-    newIgnoreNullOptions.Converters.Add(JsonFSharpConverter())
+        JsonFSharpOptions()
+            .ToJsonSerializerOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)
 
     [<AllowNullLiteral>]
     type Cls() =
@@ -256,9 +253,8 @@ module NonStruct =
         Assert.Equal("""{"y":1}""", actual)
 
     let propertyNamingPolicyOptions =
-        JsonSerializerOptions(PropertyNamingPolicy = JsonNamingPolicy.CamelCase)
-
-    propertyNamingPolicyOptions.Converters.Add(JsonFSharpConverter())
+        JsonFSharpOptions()
+            .ToJsonSerializerOptions(PropertyNamingPolicy = JsonNamingPolicy.CamelCase)
 
     type CamelCase = { CcFirst: int; CcSecond: string }
 
@@ -275,9 +271,7 @@ module NonStruct =
         Assert.Equal("""{"ccFirst":1,"ccSecond":"a"}""", actual)
 
     let propertyNameCaseInsensitiveOptions =
-        JsonSerializerOptions(PropertyNameCaseInsensitive = true)
-
-    propertyNameCaseInsensitiveOptions.Converters.Add(JsonFSharpConverter())
+        JsonFSharpOptions().ToJsonSerializerOptions(PropertyNameCaseInsensitive = true)
 
     [<Fact>]
     let ``deserialize with property case insensitive`` () =
@@ -306,14 +300,16 @@ module NonStruct =
 
     [<Fact>]
     let ``should not override allowNullFields in attribute if AllowOverride = false`` () =
-        let o = JsonSerializerOptions()
-        o.Converters.Add(JsonFSharpConverter(allowNullFields = true))
+        let o = JsonFSharpOptions().WithAllowNullFields().ToJsonSerializerOptions()
         Assert.Equal({ x = null }, JsonSerializer.Deserialize<Override>("""{"x":null}""", o))
 
     [<Fact>]
     let ``should override allowNullFields in attribute if AllowOverride = true`` () =
-        let o = JsonSerializerOptions()
-        o.Converters.Add(JsonFSharpConverter(allowNullFields = true, allowOverride = true))
+        let o =
+            JsonFSharpOptions()
+                .WithAllowNullFields()
+                .WithAllowOverride()
+                .ToJsonSerializerOptions()
         Assert.Throws<JsonException>(fun () -> JsonSerializer.Deserialize<Override>("""{"x":null}""", o) |> ignore)
         |> ignore
 
@@ -357,14 +353,14 @@ module NonStruct =
         member _.IgnoredMember = "c"
 
     let includeRecordPropertiesOptions =
-        JsonSerializerOptions(PropertyNameCaseInsensitive = true)
-
-    includeRecordPropertiesOptions.Converters.Add(JsonFSharpConverter(includeRecordProperties = true))
+        JsonFSharpOptions()
+            .WithIncludeRecordProperties()
+            .ToJsonSerializerOptions(PropertyNameCaseInsensitive = true)
 
     let dontIncludeRecordPropertiesOptions =
-        JsonSerializerOptions(PropertyNameCaseInsensitive = true)
-
-    dontIncludeRecordPropertiesOptions.Converters.Add(JsonFSharpConverter(includeRecordProperties = false))
+        JsonFSharpOptions()
+            .WithIncludeRecordProperties(false)
+            .ToJsonSerializerOptions(PropertyNameCaseInsensitive = true)
 
     [<Fact>]
     let ``serialize record properties`` () =
@@ -417,8 +413,7 @@ module Struct =
     [<Struct>]
     type B = { bx: int; by: string }
 
-    let options = JsonSerializerOptions()
-    options.Converters.Add(JsonFSharpConverter())
+    let options = JsonFSharpOptions().ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize via options`` () =
@@ -486,8 +481,7 @@ module Struct =
 
     [<Fact>]
     let allowNullFields () =
-        let options = JsonSerializerOptions()
-        options.Converters.Add(JsonFSharpConverter(allowNullFields = true))
+        let options = JsonFSharpOptions().WithAllowNullFields().ToJsonSerializerOptions()
         let actual = JsonSerializer.Deserialize("""{"bx":1,"by":null}""", options)
         Assert.Equal({ bx = 1; by = null }, actual)
 
@@ -614,13 +608,12 @@ module Struct =
         let actual = JsonSerializer.Serialize({ unignoredX = 1; ignoredY = "b" }, options)
         Assert.Equal("""{"unignoredX":1}""", actual)
 
-    let ignoreNullOptions = JsonSerializerOptions(IgnoreNullValues = true)
-    ignoreNullOptions.Converters.Add(JsonFSharpConverter())
+    let ignoreNullOptions =
+        JsonFSharpOptions().ToJsonSerializerOptions(IgnoreNullValues = true)
 
     let newIgnoreNullOptions =
-        JsonSerializerOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)
-
-    newIgnoreNullOptions.Converters.Add(JsonFSharpConverter())
+        JsonFSharpOptions()
+            .ToJsonSerializerOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)
 
     [<AllowNullLiteral>]
     type Cls() =
@@ -651,9 +644,8 @@ module Struct =
         Assert.Equal("""{"y":1}""", actual)
 
     let propertyNamingPolicyOptions =
-        JsonSerializerOptions(PropertyNamingPolicy = JsonNamingPolicy.CamelCase)
-
-    propertyNamingPolicyOptions.Converters.Add(JsonFSharpConverter())
+        JsonFSharpOptions()
+            .ToJsonSerializerOptions(PropertyNamingPolicy = JsonNamingPolicy.CamelCase)
 
     [<Struct>]
     type CamelCase = { CcFirst: int; CcSecond: string }
@@ -671,9 +663,7 @@ module Struct =
         Assert.Equal("""{"ccFirst":1,"ccSecond":"a"}""", actual)
 
     let propertyNameCaseInsensitiveOptions =
-        JsonSerializerOptions(PropertyNameCaseInsensitive = true)
-
-    propertyNameCaseInsensitiveOptions.Converters.Add(JsonFSharpConverter())
+        JsonFSharpOptions().ToJsonSerializerOptions(PropertyNameCaseInsensitive = true)
 
     [<Fact>]
     let ``deserialize with property case insensitive`` () =
@@ -693,14 +683,16 @@ module Struct =
 
     [<Fact>]
     let ``should not override allowNullFields in attribute if AllowOverride = false`` () =
-        let o = JsonSerializerOptions()
-        o.Converters.Add(JsonFSharpConverter(allowNullFields = true))
+        let o = JsonFSharpOptions().WithAllowNullFields().ToJsonSerializerOptions()
         Assert.Equal({ x = null }, JsonSerializer.Deserialize<Override>("""{"x":null}""", o))
 
     [<Fact>]
     let ``should override allowNullFields in attribute if AllowOverride = true`` () =
-        let o = JsonSerializerOptions()
-        o.Converters.Add(JsonFSharpConverter(allowNullFields = true, allowOverride = true))
+        let o =
+            JsonFSharpOptions()
+                .WithAllowNullFields()
+                .WithAllowOverride()
+                .ToJsonSerializerOptions()
         Assert.Throws<JsonException>(fun () -> JsonSerializer.Deserialize<Override>("""{"x":null}""", o) |> ignore)
         |> ignore
 
@@ -713,14 +705,14 @@ module Struct =
         member _.IgnoredMember = "c"
 
     let includeRecordPropertiesOptions =
-        JsonSerializerOptions(PropertyNameCaseInsensitive = true)
-
-    includeRecordPropertiesOptions.Converters.Add(JsonFSharpConverter(includeRecordProperties = true))
+        JsonFSharpOptions()
+            .WithIncludeRecordProperties()
+            .ToJsonSerializerOptions(PropertyNameCaseInsensitive = true)
 
     let dontIncludeRecordPropertiesOptions =
-        JsonSerializerOptions(PropertyNameCaseInsensitive = true)
-
-    dontIncludeRecordPropertiesOptions.Converters.Add(JsonFSharpConverter(includeRecordProperties = false))
+        JsonFSharpOptions()
+            .WithIncludeRecordProperties(false)
+            .ToJsonSerializerOptions(PropertyNameCaseInsensitive = true)
 
     [<Fact>]
     let ``serialize record properties`` () =

--- a/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
@@ -295,7 +295,7 @@ module NonStruct =
         with :? JsonException as e ->
             Assert.Equal("Missing field for record type Tests.Record+NonStruct+D: dx", e.Message)
 
-    [<JsonFSharpConverter(allowNullFields = false)>]
+    [<JsonFSharpConverter(AllowNullFields = false)>]
     type Override = { x: string }
 
     [<Fact>]
@@ -677,7 +677,7 @@ module Struct =
             JsonSerializer.Serialize({ CcFirst = 1; CcSecond = "a" }, propertyNameCaseInsensitiveOptions)
         Assert.Equal("""{"CcFirst":1,"CcSecond":"a"}""", actual)
 
-    [<JsonFSharpConverter(allowNullFields = false)>]
+    [<JsonFSharpConverter(AllowNullFields = false)>]
     [<Struct>]
     type Override = { x: string }
 

--- a/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
@@ -1114,7 +1114,7 @@ module NonStruct =
             let actual = JsonSerializer.Deserialize("""{"v":42}""", untaggedOptions)
             Assert.Equal(V 42, actual)
 
-    [<JsonFSharpConverter(unionTagName = "tag", unionFieldsName = "val")>]
+    [<JsonFSharpConverter(UnionTagName = "tag", UnionFieldsName = "val")>]
     type Override = A of x: int * y: string
 
     [<Fact>]
@@ -1138,7 +1138,7 @@ module NonStruct =
                 .ToJsonSerializerOptions()
         Assert.Equal("""{"tag":"A","x":123,"y":"abc"}""", JsonSerializer.Serialize(Override.A(123, "abc"), o))
 
-    [<JsonFSharpConverter(JsonUnionEncoding.InternalTag)>]
+    [<JsonFSharpConverter(UnionEncoding = JsonUnionEncoding.InternalTag)>]
     type Override2 = A of int * string
 
     [<Fact>]
@@ -2407,7 +2407,7 @@ module Struct =
             let actual = JsonSerializer.Deserialize("""{"v":42}""", untaggedOptions)
             Assert.Equal(V 42, actual)
 
-    [<JsonFSharpConverter(unionTagName = "tag", unionFieldsName = "val")>]
+    [<JsonFSharpConverter(UnionTagName = "tag", UnionFieldsName = "val")>]
     [<Struct>]
     type Override = A of x: int * y: string
 
@@ -2432,7 +2432,7 @@ module Struct =
                 .ToJsonSerializerOptions()
         Assert.Equal("""{"tag":"A","x":123,"y":"abc"}""", JsonSerializer.Serialize(Override.A(123, "abc"), o))
 
-    [<JsonFSharpConverter(JsonUnionEncoding.InternalTag)>]
+    [<JsonFSharpConverter(UnionEncoding = JsonUnionEncoding.InternalTag)>]
     [<Struct>]
     type Override2 = A of int * string
 

--- a/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
@@ -1147,7 +1147,7 @@ module NonStruct =
         Assert.Equal("""["A",123,"abc"]""", JsonSerializer.Serialize(Override2.A(123, "abc"), o))
 
     [<Fact>]
-    let ``should apply explicit overrides if allowOverride = false`` () =
+    let ``should apply explicit overrides from Default if allowOverride = false`` () =
         let o =
             JsonFSharpOptions
                 .Default()
@@ -1157,12 +1157,32 @@ module NonStruct =
         Assert.Equal("""["A",123,"abc"]""", JsonSerializer.Serialize(Override.A(123, "abc"), o))
 
     [<Fact>]
-    let ``should apply explicit overrides if allowOverride = true`` () =
+    let ``should apply explicit overrides from function if allowOverride = false`` () =
+        let o =
+            JsonFSharpOptions
+                .Default()
+                .WithAllowOverride(false)
+                .WithOverrides(fun o -> dict [ typeof<Override>, o.WithUnionInternalTag() ])
+                .ToJsonSerializerOptions()
+        Assert.Equal("""["A",123,"abc"]""", JsonSerializer.Serialize(Override.A(123, "abc"), o))
+
+    [<Fact>]
+    let ``should apply explicit overrides from Default if allowOverride = true`` () =
         let o =
             JsonFSharpOptions
                 .Default()
                 .WithAllowOverride()
                 .WithOverrides(dict [ typeof<Override>, JsonFSharpOptions.Default().WithUnionInternalTag() ])
+                .ToJsonSerializerOptions()
+        Assert.Equal("""["A",123,"abc"]""", JsonSerializer.Serialize(Override.A(123, "abc"), o))
+
+    [<Fact>]
+    let ``should apply explicit overrides from function if allowOverride = true`` () =
+        let o =
+            JsonFSharpOptions
+                .Default()
+                .WithAllowOverride()
+                .WithOverrides(fun o -> dict [ typeof<Override>, o.WithUnionInternalTag() ])
                 .ToJsonSerializerOptions()
         Assert.Equal("""["A",123,"abc"]""", JsonSerializer.Serialize(Override.A(123, "abc"), o))
 

--- a/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
@@ -36,8 +36,7 @@ module NonStruct =
         | [<JsonName(true, "jbool")>] JNb of jnbField: int
         | JNn of jnnField: int
 
-    let options = JsonSerializerOptions()
-    options.Converters.Add(JsonFSharpConverter())
+    let options = JsonFSharpOptions.Default().ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize via options`` () =
@@ -63,14 +62,17 @@ module NonStruct =
 
     [<Fact>]
     let allowNullFields () =
-        let options = JsonSerializerOptions()
-        options.Converters.Add(JsonFSharpConverter(allowNullFields = true))
+        let options =
+            JsonFSharpOptions.Default().WithAllowNullFields().ToJsonSerializerOptions()
         let actual =
             JsonSerializer.Deserialize("""{"Case":"Bc","Fields":[null,true]}""", options)
         Assert.Equal(Bc(null, true), actual)
 
-    let tagPolicyOptions = JsonSerializerOptions()
-    tagPolicyOptions.Converters.Add(JsonFSharpConverter(unionTagNamingPolicy = JsonNamingPolicy.CamelCase))
+    let tagPolicyOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionTagNamingPolicy(JsonNamingPolicy.CamelCase)
+            .ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize AdjacentTag with tag policy`` () =
@@ -94,8 +96,11 @@ module NonStruct =
             JsonSerializer.Serialize(Bc("test", true), tagPolicyOptions)
         )
 
-    let tagCaseInsensitiveOptions = JsonSerializerOptions()
-    tagCaseInsensitiveOptions.Converters.Add(JsonFSharpConverter(unionTagCaseInsensitive = true))
+    let tagCaseInsensitiveOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionTagCaseInsensitive()
+            .ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize AdjacentTag with case insensitive tag`` () =
@@ -150,8 +155,8 @@ module NonStruct =
         Assert.Equal("""null""", JsonSerializer.Serialize(Ca, options))
         Assert.Equal("""{"Case":"Cb","Fields":[32]}""", JsonSerializer.Serialize(Cb 32, options))
 
-    let externalTagOptions = JsonSerializerOptions()
-    externalTagOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.ExternalTag))
+    let externalTagOptions =
+        JsonFSharpOptions.Default().WithUnionExternalTag().ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize ExternalTag`` () =
@@ -165,11 +170,12 @@ module NonStruct =
         Assert.Equal("""{"Bb":[32]}""", JsonSerializer.Serialize(Bb 32, externalTagOptions))
         Assert.Equal("""{"Bc":["test",true]}""", JsonSerializer.Serialize(Bc("test", true), externalTagOptions))
 
-    let externalTagPolicyOptions = JsonSerializerOptions()
-
-    externalTagPolicyOptions.Converters.Add(
-        JsonFSharpConverter(JsonUnionEncoding.ExternalTag, unionTagNamingPolicy = JsonNamingPolicy.CamelCase)
-    )
+    let externalTagPolicyOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionExternalTag()
+            .WithUnionTagNamingPolicy(JsonNamingPolicy.CamelCase)
+            .ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize ExternalTag with tag policy`` () =
@@ -198,8 +204,8 @@ module NonStruct =
         Assert.Equal("""{"true":[1]}""", JsonSerializer.Serialize(JNb 1, externalTagOptions))
         Assert.Equal("""{"JNn":[1]}""", JsonSerializer.Serialize(JNn 1, externalTagOptions))
 
-    let internalTagOptions = JsonSerializerOptions()
-    internalTagOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.InternalTag))
+    let internalTagOptions =
+        JsonFSharpOptions.Default().WithUnionInternalTag().ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize InternalTag`` () =
@@ -213,11 +219,12 @@ module NonStruct =
         Assert.Equal("""["Bb",32]""", JsonSerializer.Serialize(Bb 32, internalTagOptions))
         Assert.Equal("""["Bc","test",true]""", JsonSerializer.Serialize(Bc("test", true), internalTagOptions))
 
-    let internalTagPolicyOptions = JsonSerializerOptions()
-
-    internalTagPolicyOptions.Converters.Add(
-        JsonFSharpConverter(JsonUnionEncoding.InternalTag, unionTagNamingPolicy = JsonNamingPolicy.CamelCase)
-    )
+    let internalTagPolicyOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionInternalTag()
+            .WithUnionTagNamingPolicy(JsonNamingPolicy.CamelCase)
+            .ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize InternalTag with tag policy`` () =
@@ -246,8 +253,8 @@ module NonStruct =
         Assert.Equal("""[true,1]""", JsonSerializer.Serialize(JNb 1, internalTagOptions))
         Assert.Equal("""["JNn",1]""", JsonSerializer.Serialize(JNn 1, internalTagOptions))
 
-    let untaggedOptions = JsonSerializerOptions()
-    untaggedOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.Untagged))
+    let untaggedOptions =
+        JsonFSharpOptions.Default().WithUnionUntagged().ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize Untagged`` () =
@@ -275,15 +282,13 @@ module NonStruct =
         Assert.Equal("""{"jnbField":1}""", JsonSerializer.Serialize(JNb 1, untaggedOptions))
         Assert.Equal("""{"jnnField":1}""", JsonSerializer.Serialize(JNn 1, untaggedOptions))
 
-    let adjacentTagNamedFieldsOptions = JsonSerializerOptions()
-
-    adjacentTagNamedFieldsOptions.Converters.Add(
-        JsonFSharpConverter(
-            JsonUnionEncoding.AdjacentTag
-            ||| JsonUnionEncoding.NamedFields
-            ||| JsonUnionEncoding.AllowUnorderedTag
-        )
-    )
+    let adjacentTagNamedFieldsOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionAdjacentTag()
+            .WithUnionNamedFields()
+            .WithUnionAllowUnorderedTag()
+            .ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize AdjacentTag NamedFields`` () =
@@ -319,16 +324,14 @@ module NonStruct =
             JsonSerializer.Serialize(Bc("test", true), adjacentTagNamedFieldsOptions)
         )
 
-    let adjacentTagNamedFieldsTagPolicyOptions = JsonSerializerOptions()
-
-    adjacentTagNamedFieldsTagPolicyOptions.Converters.Add(
-        JsonFSharpConverter(
-            JsonUnionEncoding.AdjacentTag
-            ||| JsonUnionEncoding.NamedFields
-            ||| JsonUnionEncoding.AllowUnorderedTag,
-            unionTagNamingPolicy = JsonNamingPolicy.CamelCase
-        )
-    )
+    let adjacentTagNamedFieldsTagPolicyOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionAdjacentTag()
+            .WithUnionNamedFields()
+            .WithUnionAllowUnorderedTag()
+            .WithUnionTagNamingPolicy(JsonNamingPolicy.CamelCase)
+            .ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize AdjacentTag NamedFields with tag policy`` () =
@@ -416,11 +419,12 @@ module NonStruct =
             JsonSerializer.Serialize(JNn 1, adjacentTagNamedFieldsOptions)
         )
 
-    let externalTagNamedFieldsOptions = JsonSerializerOptions()
-
-    externalTagNamedFieldsOptions.Converters.Add(
-        JsonFSharpConverter(JsonUnionEncoding.ExternalTag ||| JsonUnionEncoding.NamedFields)
-    )
+    let externalTagNamedFieldsOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionExternalTag()
+            .WithUnionNamedFields()
+            .ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize ExternalTag NamedFields`` () =
@@ -440,14 +444,13 @@ module NonStruct =
             JsonSerializer.Serialize(Bc("test", true), externalTagNamedFieldsOptions)
         )
 
-    let externalTagNamedFieldsTagPolicyOptions = JsonSerializerOptions()
-
-    externalTagNamedFieldsTagPolicyOptions.Converters.Add(
-        JsonFSharpConverter(
-            JsonUnionEncoding.ExternalTag ||| JsonUnionEncoding.NamedFields,
-            unionTagNamingPolicy = JsonNamingPolicy.CamelCase
-        )
-    )
+    let externalTagNamedFieldsTagPolicyOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionExternalTag()
+            .WithUnionNamedFields()
+            .WithUnionTagNamingPolicy(JsonNamingPolicy.CamelCase)
+            .ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize ExternalTag NamedFields with tag policy`` () =
@@ -495,15 +498,12 @@ module NonStruct =
         Assert.Equal("""{"true":{"jnbField":1}}""", JsonSerializer.Serialize(JNb 1, externalTagNamedFieldsOptions))
         Assert.Equal("""{"JNn":{"jnnField":1}}""", JsonSerializer.Serialize(JNn 1, externalTagNamedFieldsOptions))
 
-    let internalTagNamedFieldsOptions = JsonSerializerOptions()
-
-    internalTagNamedFieldsOptions.Converters.Add(
-        JsonFSharpConverter(
-            JsonUnionEncoding.InternalTag
-            ||| JsonUnionEncoding.NamedFields
-            ||| JsonUnionEncoding.Default
-        )
-    )
+    let internalTagNamedFieldsOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionInternalTag()
+            .WithUnionNamedFields()
+            .ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize InternalTag NamedFields`` () =
@@ -566,16 +566,14 @@ module NonStruct =
             )
         )
 
-    let internalTagNamedFieldsTagPolicyOptions = JsonSerializerOptions()
-
-    internalTagNamedFieldsTagPolicyOptions.Converters.Add(
-        JsonFSharpConverter(
-            JsonUnionEncoding.InternalTag
-            ||| JsonUnionEncoding.NamedFields
-            ||| JsonUnionEncoding.AllowUnorderedTag,
-            unionTagNamingPolicy = JsonNamingPolicy.CamelCase
-        )
-    )
+    let internalTagNamedFieldsTagPolicyOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionInternalTag()
+            .WithUnionNamedFields()
+            .WithUnionAllowUnorderedTag()
+            .WithUnionTagNamingPolicy(JsonNamingPolicy.CamelCase)
+            .ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize InternalTag NamedFields with tag policy`` () =
@@ -642,16 +640,14 @@ module NonStruct =
         Assert.Equal("""{"Case":true,"jnbField":1}""", JsonSerializer.Serialize(JNb 1, internalTagNamedFieldsOptions))
         Assert.Equal("""{"Case":"JNn","jnnField":1}""", JsonSerializer.Serialize(JNn 1, internalTagNamedFieldsOptions))
 
-    let internalTagNamedFieldsConfiguredTagOptions = JsonSerializerOptions()
-
-    internalTagNamedFieldsConfiguredTagOptions.Converters.Add(
-        JsonFSharpConverter(
-            JsonUnionEncoding.InternalTag
-            ||| JsonUnionEncoding.NamedFields
-            ||| JsonUnionEncoding.AllowUnorderedTag,
-            "type"
-        )
-    )
+    let internalTagNamedFieldsConfiguredTagOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionInternalTag()
+            .WithUnionNamedFields()
+            .WithUnionAllowUnorderedTag()
+            .WithUnionTagName("type")
+            .ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize InternalTag NamedFields alternative Tag`` () =
@@ -687,11 +683,14 @@ module NonStruct =
             JsonSerializer.Serialize(Bc("test", true), internalTagNamedFieldsConfiguredTagOptions)
         )
 
-    let adjacentTagNamedFieldsConfiguredFieldsOptions = JsonSerializerOptions()
-
-    adjacentTagNamedFieldsConfiguredFieldsOptions.Converters.Add(
-        JsonFSharpConverter(JsonUnionEncoding.AdjacentTag ||| JsonUnionEncoding.AllowUnorderedTag, "type", "args")
-    )
+    let adjacentTagNamedFieldsConfiguredFieldsOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionAdjacentTag()
+            .WithUnionAllowUnorderedTag()
+            .WithUnionTagName("type")
+            .WithUnionFieldsName("args")
+            .ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize AdjacentTag NamedFields alternative Fields`` () =
@@ -727,11 +726,11 @@ module NonStruct =
             JsonSerializer.Serialize(Bc("test", true), adjacentTagNamedFieldsConfiguredFieldsOptions)
         )
 
-    let unwrapSingleFieldCasesOptions = JsonSerializerOptions()
-
-    unwrapSingleFieldCasesOptions.Converters.Add(
-        JsonFSharpConverter(JsonUnionEncoding.Default ||| JsonUnionEncoding.UnwrapSingleFieldCases)
-    )
+    let unwrapSingleFieldCasesOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionUnwrapSingleFieldCases()
+            .ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize unwrapped single-field cases`` () =
@@ -763,8 +762,11 @@ module NonStruct =
         Assert.Equal({ o = Some 123 }, JsonSerializer.Deserialize("""{"o":123}""", options))
         Assert.Equal({ o = None }, JsonSerializer.Deserialize("""{"o":null}""", options))
 
-    let unwrapFieldlessTagsOptions = JsonSerializerOptions()
-    unwrapFieldlessTagsOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.UnwrapFieldlessTags))
+    let unwrapFieldlessTagsOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionUnwrapFieldlessTags()
+            .ToJsonSerializerOptions()
 
     type S = { b: B }
 
@@ -786,11 +788,12 @@ module NonStruct =
             JsonSerializer.Serialize(Bc("test", true), unwrapFieldlessTagsOptions)
         )
 
-    let unwrapFieldlessTagsTagPolicyOptions = JsonSerializerOptions()
-
-    unwrapFieldlessTagsTagPolicyOptions.Converters.Add(
-        JsonFSharpConverter(JsonUnionEncoding.UnwrapFieldlessTags, unionTagNamingPolicy = JsonNamingPolicy.CamelCase)
-    )
+    let unwrapFieldlessTagsTagPolicyOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionUnwrapFieldlessTags()
+            .WithUnionTagNamingPolicy(JsonNamingPolicy.CamelCase)
+            .ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize UnwrapFieldlessTags with tag policy`` () =
@@ -836,8 +839,12 @@ module NonStruct =
             JsonSerializer.Serialize(NamedWithArgs 42, unwrapFieldlessTagsOptions)
         )
 
-    let nonUnwrapOptionOptions = JsonSerializerOptions()
-    nonUnwrapOptionOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.AdjacentTag))
+    let nonUnwrapOptionOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionAdjacentTag()
+            .WithUnwrapOption(false)
+            .ToJsonSerializerOptions()
 
     [<Fact>]
     let ``serialize non-UnwrapOption`` () =
@@ -855,18 +862,19 @@ module NonStruct =
         )
         Assert.Equal({ o = None }, JsonSerializer.Deserialize("""{"o":null}""", nonUnwrapOptionOptions))
 
-    let ignoreNullOptions = JsonSerializerOptions(IgnoreNullValues = true)
-
-    ignoreNullOptions.Converters.Add(
-        JsonFSharpConverter(JsonUnionEncoding.InternalTag ||| JsonUnionEncoding.NamedFields)
-    )
+    let ignoreNullOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionInternalTag()
+            .WithUnionNamedFields()
+            .ToJsonSerializerOptions(IgnoreNullValues = true)
 
     let newIgnoreNullOptions =
-        JsonSerializerOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)
-
-    newIgnoreNullOptions.Converters.Add(
-        JsonFSharpConverter(JsonUnionEncoding.InternalTag ||| JsonUnionEncoding.NamedFields)
-    )
+        JsonFSharpOptions
+            .Default()
+            .WithUnionInternalTag()
+            .WithUnionNamedFields()
+            .ToJsonSerializerOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)
 
     [<AllowNullLiteral>]
     type Cls() =
@@ -898,9 +906,10 @@ module NonStruct =
         Assert.Equal("""{"Case":"Foo","x":1}""", actual)
 
     let propertyNamingPolicyOptions =
-        JsonSerializerOptions(PropertyNamingPolicy = JsonNamingPolicy.CamelCase)
-
-    propertyNamingPolicyOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.Untagged))
+        JsonFSharpOptions
+            .Default()
+            .WithUnionUntagged()
+            .ToJsonSerializerOptions(PropertyNamingPolicy = JsonNamingPolicy.CamelCase)
 
     type CamelCase = CCA of CcFirst: int * CcSecond: string
 
@@ -916,11 +925,11 @@ module NonStruct =
         Assert.Equal("""{"ccFirst":1,"ccSecond":"a"}""", actual)
 
     let propertyNameCaseInsensitiveOptions =
-        JsonSerializerOptions(PropertyNameCaseInsensitive = true)
-
-    propertyNameCaseInsensitiveOptions.Converters.Add(
-        JsonFSharpConverter(JsonUnionEncoding.InternalTag ||| JsonUnionEncoding.NamedFields)
-    )
+        JsonFSharpOptions
+            .Default()
+            .WithUnionInternalTag()
+            .WithUnionNamedFields()
+            .ToJsonSerializerOptions(PropertyNameCaseInsensitive = true)
 
     [<Fact>]
     let ``deserialize with property case insensitive`` () =
@@ -938,9 +947,10 @@ module NonStruct =
         Assert.Equal("""{"Case":"CCA","CcFirst":1,"CcSecond":"a"}""", actual)
 
     let propertyNameCaseInsensitiveUntaggedOptions =
-        JsonSerializerOptions(PropertyNameCaseInsensitive = true)
-
-    propertyNameCaseInsensitiveUntaggedOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.Untagged))
+        JsonFSharpOptions
+            .Default()
+            .WithUnionUntagged()
+            .ToJsonSerializerOptions(PropertyNameCaseInsensitive = true)
 
     [<Fact>]
     let ``deserialize untagged with property case insensitive`` () =
@@ -964,11 +974,11 @@ module NonStruct =
     let ``serialize unwrapped single-case`` () =
         Assert.Equal("\"foo\"", JsonSerializer.Serialize(Unwrapped "foo", options))
 
-    let noNewtypeOptions = JsonSerializerOptions()
-
-    noNewtypeOptions.Converters.Add(
-        JsonFSharpConverter(JsonUnionEncoding.Default &&& ~~~JsonUnionEncoding.UnwrapSingleCaseUnions)
-    )
+    let noNewtypeOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionUnwrapSingleCaseUnions(false)
+            .ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize non-unwrapped single-case`` () =
@@ -989,16 +999,20 @@ module NonStruct =
     [<Fact>]
     let ``serializes union with unit field`` () =
         let options =
-            JsonSerializerOptions(PropertyNamingPolicy = JsonNamingPolicy.CamelCase)
-        options.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.AdjacentTag))
+            JsonFSharpOptions
+                .Default()
+                .WithUnionAdjacentTag()
+                .ToJsonSerializerOptions(PropertyNamingPolicy = JsonNamingPolicy.CamelCase)
         let actual = JsonSerializer.Serialize(UWUF(42, ()), options)
         Assert.Equal("""{"Case":"UWUF","Fields":[42,null]}""", actual)
 
     [<Fact>]
     let ``deserializes union with unit field`` () =
         let options =
-            JsonSerializerOptions(PropertyNamingPolicy = JsonNamingPolicy.CamelCase)
-        options.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.AdjacentTag))
+            JsonFSharpOptions
+                .Default()
+                .WithUnionAdjacentTag()
+                .ToJsonSerializerOptions(PropertyNamingPolicy = JsonNamingPolicy.CamelCase)
         let actual =
             JsonSerializer.Deserialize("""{"Case":"UWUF","Fields":[42,null]}""", options)
         Assert.Equal(UWUF(42, ()), actual)
@@ -1011,11 +1025,12 @@ module NonStruct =
 
         and R = { x: int; y: float }
 
-        let adjacentTagOptions = JsonSerializerOptions()
-
-        adjacentTagOptions.Converters.Add(
-            JsonFSharpConverter(JsonUnionEncoding.AdjacentTag ||| JsonUnionEncoding.UnwrapRecordCases)
-        )
+        let adjacentTagOptions =
+            JsonFSharpOptions
+                .Default()
+                .WithUnionAdjacentTag()
+                .WithUnionUnwrapRecordCases()
+                .ToJsonSerializerOptions()
 
         [<Fact>]
         let ``serialize with AdjacentTag`` () =
@@ -1033,11 +1048,12 @@ module NonStruct =
                 JsonSerializer.Deserialize("""{"Case":"V","Fields":{"v":42}}""", adjacentTagOptions)
             Assert.Equal(V 42, actual)
 
-        let externalTagOptions = JsonSerializerOptions()
-
-        externalTagOptions.Converters.Add(
-            JsonFSharpConverter(JsonUnionEncoding.ExternalTag ||| JsonUnionEncoding.UnwrapRecordCases)
-        )
+        let externalTagOptions =
+            JsonFSharpOptions
+                .Default()
+                .WithUnionExternalTag()
+                .WithUnionUnwrapRecordCases()
+                .ToJsonSerializerOptions()
 
         [<Fact>]
         let ``serialize with externalTag`` () =
@@ -1054,11 +1070,12 @@ module NonStruct =
             let actual = JsonSerializer.Deserialize("""{"V":{"v":42}}""", externalTagOptions)
             Assert.Equal(V 42, actual)
 
-        let internalTagOptions = JsonSerializerOptions()
-
-        internalTagOptions.Converters.Add(
-            JsonFSharpConverter(JsonUnionEncoding.InternalTag ||| JsonUnionEncoding.UnwrapRecordCases)
-        )
+        let internalTagOptions =
+            JsonFSharpOptions
+                .Default()
+                .WithUnionInternalTag()
+                .WithUnionUnwrapRecordCases()
+                .ToJsonSerializerOptions()
 
         [<Fact>]
         let ``serialize with internalTag`` () =
@@ -1076,11 +1093,12 @@ module NonStruct =
                 JsonSerializer.Deserialize("""{"Case":"V","v":42}""", internalTagOptions)
             Assert.Equal(V 42, actual)
 
-        let untaggedOptions = JsonSerializerOptions()
-
-        untaggedOptions.Converters.Add(
-            JsonFSharpConverter(JsonUnionEncoding.Untagged ||| JsonUnionEncoding.UnwrapRecordCases)
-        )
+        let untaggedOptions =
+            JsonFSharpOptions
+                .Default()
+                .WithUnionUntagged()
+                .WithUnionUnwrapRecordCases()
+                .ToJsonSerializerOptions()
 
         [<Fact>]
         let ``serialize with untagged`` () =
@@ -1101,22 +1119,23 @@ module NonStruct =
 
     [<Fact>]
     let ``should not override tag name in attribute if AllowOverride = false`` () =
-        let o = JsonSerializerOptions()
-        o.Converters.Add(JsonFSharpConverter())
+        let o = JsonFSharpOptions.Default().ToJsonSerializerOptions()
         Assert.Equal("""{"Case":"A","Fields":[123,"abc"]}""", JsonSerializer.Serialize(Override.A(123, "abc"), o))
 
     [<Fact>]
     let ``should override tag name in attribute if AllowOverride = true`` () =
-        let o = JsonSerializerOptions()
-        o.Converters.Add(JsonFSharpConverter(allowOverride = true))
+        let o = JsonFSharpOptions.Default().WithAllowOverride().ToJsonSerializerOptions()
         Assert.Equal("""{"tag":"A","val":[123,"abc"]}""", JsonSerializer.Serialize(Override.A(123, "abc"), o))
 
     [<Fact>]
     let ``should not override JsonEncoding if not specified`` () =
-        let o = JsonSerializerOptions()
-        o.Converters.Add(
-            JsonFSharpConverter(JsonUnionEncoding.InternalTag ||| JsonUnionEncoding.NamedFields, allowOverride = true)
-        )
+        let o =
+            JsonFSharpOptions
+                .Default()
+                .WithUnionInternalTag()
+                .WithUnionNamedFields()
+                .WithAllowOverride()
+                .ToJsonSerializerOptions()
         Assert.Equal("""{"tag":"A","x":123,"y":"abc"}""", JsonSerializer.Serialize(Override.A(123, "abc"), o))
 
     [<JsonFSharpConverter(JsonUnionEncoding.InternalTag)>]
@@ -1124,56 +1143,60 @@ module NonStruct =
 
     [<Fact>]
     let ``should override JsonEncoding if specified`` () =
-        let o = JsonSerializerOptions()
-        o.Converters.Add(JsonFSharpConverter(allowOverride = true))
+        let o = JsonFSharpOptions.Default().WithAllowOverride().ToJsonSerializerOptions()
         Assert.Equal("""["A",123,"abc"]""", JsonSerializer.Serialize(Override2.A(123, "abc"), o))
 
     [<Fact>]
     let ``should apply explicit overrides if allowOverride = false`` () =
-        let o = JsonSerializerOptions()
-        o.Converters.Add(
-            JsonFSharpConverter(overrides = dict [ typeof<Override>, JsonFSharpOptions(JsonUnionEncoding.InternalTag) ])
-        )
+        let o =
+            JsonFSharpOptions
+                .Default()
+                .WithAllowOverride(false)
+                .WithOverrides(dict [ typeof<Override>, JsonFSharpOptions.Default().WithUnionInternalTag() ])
+                .ToJsonSerializerOptions()
         Assert.Equal("""["A",123,"abc"]""", JsonSerializer.Serialize(Override.A(123, "abc"), o))
 
     [<Fact>]
     let ``should apply explicit overrides if allowOverride = true`` () =
-        let o = JsonSerializerOptions()
-        o.Converters.Add(
-            JsonFSharpConverter(
-                allowOverride = true,
-                overrides = dict [ typeof<Override>, JsonFSharpOptions(JsonUnionEncoding.InternalTag) ]
-            )
-        )
+        let o =
+            JsonFSharpOptions
+                .Default()
+                .WithAllowOverride()
+                .WithOverrides(dict [ typeof<Override>, JsonFSharpOptions.Default().WithUnionInternalTag() ])
+                .ToJsonSerializerOptions()
         Assert.Equal("""["A",123,"abc"]""", JsonSerializer.Serialize(Override.A(123, "abc"), o))
 
     [<Fact>]
     let ``should apply explicit overrides inheriting JsonUnionEncoding`` () =
-        let o = JsonSerializerOptions()
-        o.Converters.Add(
-            JsonFSharpConverter(
-                JsonUnionEncoding.InternalTag ||| JsonUnionEncoding.NamedFields,
-                overrides = dict [ typeof<Override>, JsonFSharpOptions(unionTagName = "tag") ]
-            )
-        )
-        Assert.Equal("""{"tag":"A","x":123,"y":"abc"}""", JsonSerializer.Serialize(Override.A(123, "abc"), o))
+        let o =
+            JsonFSharpOptions
+                .Default()
+                .WithUnionInternalTag()
+                .WithUnionNamedFields()
+                .WithOverrides(
+                    dict [ typeof<Override>, JsonFSharpOptions.InheritUnionEncoding().WithUnionTagName("tag2") ]
+                )
+                .ToJsonSerializerOptions()
+        Assert.Equal("""{"tag2":"A","x":123,"y":"abc"}""", JsonSerializer.Serialize(Override.A(123, "abc"), o))
 
-    type NamedAfterTypes =
-        | NTA of int
-        | NTB of int * string
-        | NTC of X: int
-        | NTD of X: int * Y: string
-        | NTE of string * string
+    type NamedAfterTypesA = NTA of int
 
-    let namedAfterTypesOptions = JsonSerializerOptions()
+    type NamedAfterTypesB = NTB of int * string
 
-    namedAfterTypesOptions.Converters.Add(
-        JsonFSharpConverter(
-            JsonUnionEncoding.InternalTag
-            ||| JsonUnionEncoding.NamedFields
-            ||| JsonUnionEncoding.UnionFieldNamesFromTypes
-        )
-    )
+    type NamedAfterTypesC = NTC of X: int
+
+    type NamedAfterTypesD = NTD of X: int * Y: string
+
+    type NamedAfterTypesE = NTE of string * string
+
+    let namedAfterTypesOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionInternalTag()
+            .WithUnionNamedFields()
+            .WithUnionFieldNamesFromTypes()
+            .WithUnionUnwrapSingleCaseUnions(false)
+            .ToJsonSerializerOptions()
 
     [<Fact>]
     let ``serialize UnionFieldNamesFromTypes`` () =
@@ -1209,16 +1232,15 @@ module NonStruct =
             JsonSerializer.Deserialize("""{"Case":"NTE","String1":"123","String2":"test"}""", namedAfterTypesOptions)
         )
 
-    let namedAfterTypesOptionsWithNamingPolicy = JsonSerializerOptions()
-
-    namedAfterTypesOptionsWithNamingPolicy.Converters.Add(
-        JsonFSharpConverter(
-            JsonUnionEncoding.InternalTag
-            ||| JsonUnionEncoding.NamedFields
-            ||| JsonUnionEncoding.UnionFieldNamesFromTypes,
-            unionFieldNamingPolicy = JsonNamingPolicy.CamelCase
-        )
-    )
+    let namedAfterTypesOptionsWithNamingPolicy =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionInternalTag()
+            .WithUnionNamedFields()
+            .WithUnionFieldNamesFromTypes()
+            .WithUnionFieldNamingPolicy(JsonNamingPolicy.CamelCase)
+            .WithUnionUnwrapSingleCaseUnions(false)
+            .ToJsonSerializerOptions()
 
     [<Fact>]
     let ``serialize UnionFieldNamesFromTypes with unionFieldNamingPolicy`` () =
@@ -1305,8 +1327,7 @@ module Struct =
         | [<JsonName(true, "jbool")>] JNb of jnbField: int
         | JNn of jnnField: int
 
-    let options = JsonSerializerOptions()
-    options.Converters.Add(JsonFSharpConverter())
+    let options = JsonFSharpOptions.Default().ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize via options`` () =
@@ -1332,8 +1353,8 @@ module Struct =
 
     [<Fact>]
     let allowNullFields () =
-        let options = JsonSerializerOptions()
-        options.Converters.Add(JsonFSharpConverter(allowNullFields = true))
+        let options =
+            JsonFSharpOptions.Default().WithAllowNullFields().ToJsonSerializerOptions()
         let actual =
             JsonSerializer.Deserialize("""{"Case":"Bc","Fields":[null,true]}""", options)
         Assert.Equal(Bc(null, true), actual)
@@ -1351,8 +1372,11 @@ module Struct =
         Assert.Equal({ vo = ValueSome 123 }, JsonSerializer.Deserialize("""{"vo":123}""", options))
         Assert.Equal({ vo = ValueNone }, JsonSerializer.Deserialize("""{"vo":null}""", options))
 
-    let tagPolicyOptions = JsonSerializerOptions()
-    tagPolicyOptions.Converters.Add(JsonFSharpConverter(unionTagNamingPolicy = JsonNamingPolicy.CamelCase))
+    let tagPolicyOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionTagNamingPolicy(JsonNamingPolicy.CamelCase)
+            .ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize AdjacentTag with tag policy`` () =
@@ -1376,8 +1400,11 @@ module Struct =
             JsonSerializer.Serialize(Bc("test", true), tagPolicyOptions)
         )
 
-    let tagCaseInsensitiveOptions = JsonSerializerOptions()
-    tagCaseInsensitiveOptions.Converters.Add(JsonFSharpConverter(unionTagCaseInsensitive = true))
+    let tagCaseInsensitiveOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionTagCaseInsensitive()
+            .ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize AdjacentTag with case insensitive tag`` () =
@@ -1416,8 +1443,8 @@ module Struct =
         Assert.Equal("""{"Case":true,"Fields":[1]}""", JsonSerializer.Serialize(JNb 1, options))
         Assert.Equal("""{"Case":"JNn","Fields":[1]}""", JsonSerializer.Serialize(JNn 1, options))
 
-    let externalTagOptions = JsonSerializerOptions()
-    externalTagOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.ExternalTag))
+    let externalTagOptions =
+        JsonFSharpOptions.Default().WithUnionExternalTag().ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize ExternalTag`` () =
@@ -1431,11 +1458,12 @@ module Struct =
         Assert.Equal("""{"Bb":[32]}""", JsonSerializer.Serialize(Bb 32, externalTagOptions))
         Assert.Equal("""{"Bc":["test",true]}""", JsonSerializer.Serialize(Bc("test", true), externalTagOptions))
 
-    let externalTagPolicyOptions = JsonSerializerOptions()
-
-    externalTagPolicyOptions.Converters.Add(
-        JsonFSharpConverter(JsonUnionEncoding.ExternalTag, unionTagNamingPolicy = JsonNamingPolicy.CamelCase)
-    )
+    let externalTagPolicyOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionExternalTag()
+            .WithUnionTagNamingPolicy(JsonNamingPolicy.CamelCase)
+            .ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize ExternalTag with tag policy`` () =
@@ -1464,8 +1492,8 @@ module Struct =
         Assert.Equal("""{"true":[1]}""", JsonSerializer.Serialize(JNb 1, externalTagOptions))
         Assert.Equal("""{"JNn":[1]}""", JsonSerializer.Serialize(JNn 1, externalTagOptions))
 
-    let internalTagOptions = JsonSerializerOptions()
-    internalTagOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.InternalTag))
+    let internalTagOptions =
+        JsonFSharpOptions.Default().WithUnionInternalTag().ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize InternalTag`` () =
@@ -1479,11 +1507,12 @@ module Struct =
         Assert.Equal("""["Bb",32]""", JsonSerializer.Serialize(Bb 32, internalTagOptions))
         Assert.Equal("""["Bc","test",true]""", JsonSerializer.Serialize(Bc("test", true), internalTagOptions))
 
-    let internalTagPolicyOptions = JsonSerializerOptions()
-
-    internalTagPolicyOptions.Converters.Add(
-        JsonFSharpConverter(JsonUnionEncoding.InternalTag, unionTagNamingPolicy = JsonNamingPolicy.CamelCase)
-    )
+    let internalTagPolicyOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionInternalTag()
+            .WithUnionTagNamingPolicy(JsonNamingPolicy.CamelCase)
+            .ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize InternalTag with tag policy`` () =
@@ -1512,8 +1541,8 @@ module Struct =
         Assert.Equal("""[true,1]""", JsonSerializer.Serialize(JNb 1, internalTagOptions))
         Assert.Equal("""["JNn",1]""", JsonSerializer.Serialize(JNn 1, internalTagOptions))
 
-    let untaggedOptions = JsonSerializerOptions()
-    untaggedOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.Untagged))
+    let untaggedOptions =
+        JsonFSharpOptions.Default().WithUnionUntagged().ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize Untagged`` () =
@@ -1542,15 +1571,13 @@ module Struct =
         Assert.Equal("""{"jnbField":1}""", JsonSerializer.Serialize(JNb 1, untaggedOptions))
         Assert.Equal("""{"jnnField":1}""", JsonSerializer.Serialize(JNn 1, untaggedOptions))
 
-    let adjacentTagNamedFieldsOptions = JsonSerializerOptions()
-
-    adjacentTagNamedFieldsOptions.Converters.Add(
-        JsonFSharpConverter(
-            JsonUnionEncoding.AdjacentTag
-            ||| JsonUnionEncoding.NamedFields
-            ||| JsonUnionEncoding.AllowUnorderedTag
-        )
-    )
+    let adjacentTagNamedFieldsOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionAdjacentTag()
+            .WithUnionNamedFields()
+            .WithUnionAllowUnorderedTag()
+            .ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize AdjacentTag NamedFields`` () =
@@ -1586,16 +1613,14 @@ module Struct =
             JsonSerializer.Serialize(Bc("test", true), adjacentTagNamedFieldsOptions)
         )
 
-    let adjacentTagNamedFieldsTagPolicyOptions = JsonSerializerOptions()
-
-    adjacentTagNamedFieldsTagPolicyOptions.Converters.Add(
-        JsonFSharpConverter(
-            JsonUnionEncoding.AdjacentTag
-            ||| JsonUnionEncoding.NamedFields
-            ||| JsonUnionEncoding.AllowUnorderedTag,
-            unionTagNamingPolicy = JsonNamingPolicy.CamelCase
-        )
-    )
+    let adjacentTagNamedFieldsTagPolicyOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionAdjacentTag()
+            .WithUnionNamedFields()
+            .WithUnionAllowUnorderedTag()
+            .WithUnionTagNamingPolicy(JsonNamingPolicy.CamelCase)
+            .ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize AdjacentTag NamedFields with tag policy`` () =
@@ -1683,11 +1708,12 @@ module Struct =
             JsonSerializer.Serialize(JNn 1, adjacentTagNamedFieldsOptions)
         )
 
-    let externalTagNamedFieldsOptions = JsonSerializerOptions()
-
-    externalTagNamedFieldsOptions.Converters.Add(
-        JsonFSharpConverter(JsonUnionEncoding.ExternalTag ||| JsonUnionEncoding.NamedFields)
-    )
+    let externalTagNamedFieldsOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionExternalTag()
+            .WithUnionNamedFields()
+            .ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize ExternalTag NamedFields`` () =
@@ -1707,14 +1733,13 @@ module Struct =
             JsonSerializer.Serialize(Bc("test", true), externalTagNamedFieldsOptions)
         )
 
-    let externalTagNamedFieldsTagPolicyOptions = JsonSerializerOptions()
-
-    externalTagNamedFieldsTagPolicyOptions.Converters.Add(
-        JsonFSharpConverter(
-            JsonUnionEncoding.ExternalTag ||| JsonUnionEncoding.NamedFields,
-            unionTagNamingPolicy = JsonNamingPolicy.CamelCase
-        )
-    )
+    let externalTagNamedFieldsTagPolicyOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionExternalTag()
+            .WithUnionNamedFields()
+            .WithUnionTagNamingPolicy(JsonNamingPolicy.CamelCase)
+            .ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize ExternalTag NamedFields with tag policy`` () =
@@ -1762,7 +1787,12 @@ module Struct =
         Assert.Equal("""{"true":{"jnbField":1}}""", JsonSerializer.Serialize(JNb 1, externalTagNamedFieldsOptions))
         Assert.Equal("""{"JNn":{"jnnField":1}}""", JsonSerializer.Serialize(JNn 1, externalTagNamedFieldsOptions))
 
-    let internalTagNamedFieldsOptions = JsonSerializerOptions()
+    let internalTagNamedFieldsOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionInternalTag()
+            .WithUnionNamedFields()
+            .ToJsonSerializerOptions()
 
     internalTagNamedFieldsOptions.Converters.Add(
         JsonFSharpConverter(
@@ -1834,16 +1864,14 @@ module Struct =
             )
         )
 
-    let internalTagNamedFieldsTagPolicyOptions = JsonSerializerOptions()
-
-    internalTagNamedFieldsTagPolicyOptions.Converters.Add(
-        JsonFSharpConverter(
-            JsonUnionEncoding.InternalTag
-            ||| JsonUnionEncoding.NamedFields
-            ||| JsonUnionEncoding.AllowUnorderedTag,
-            unionTagNamingPolicy = JsonNamingPolicy.CamelCase
-        )
-    )
+    let internalTagNamedFieldsTagPolicyOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionInternalTag()
+            .WithUnionNamedFields()
+            .WithUnionAllowUnorderedTag()
+            .WithUnionTagNamingPolicy(JsonNamingPolicy.CamelCase)
+            .ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize InternalTag NamedFields with tag policy`` () =
@@ -1910,16 +1938,14 @@ module Struct =
         Assert.Equal("""{"Case":true,"jnbField":1}""", JsonSerializer.Serialize(JNb 1, internalTagNamedFieldsOptions))
         Assert.Equal("""{"Case":"JNn","jnnField":1}""", JsonSerializer.Serialize(JNn 1, internalTagNamedFieldsOptions))
 
-    let internalTagNamedFieldsConfiguredTagOptions = JsonSerializerOptions()
-
-    internalTagNamedFieldsConfiguredTagOptions.Converters.Add(
-        JsonFSharpConverter(
-            JsonUnionEncoding.InternalTag
-            ||| JsonUnionEncoding.NamedFields
-            ||| JsonUnionEncoding.AllowUnorderedTag,
-            "type"
-        )
-    )
+    let internalTagNamedFieldsConfiguredTagOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionInternalTag()
+            .WithUnionNamedFields()
+            .WithUnionAllowUnorderedTag()
+            .WithUnionTagName("type")
+            .ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize InternalTag NamedFields alternative Tag`` () =
@@ -1955,11 +1981,14 @@ module Struct =
             JsonSerializer.Serialize(Bc("test", true), internalTagNamedFieldsConfiguredTagOptions)
         )
 
-    let adjacentTagConfiguredFieldsOptions = JsonSerializerOptions()
-
-    adjacentTagConfiguredFieldsOptions.Converters.Add(
-        JsonFSharpConverter(JsonUnionEncoding.AdjacentTag ||| JsonUnionEncoding.AllowUnorderedTag, "type", "args")
-    )
+    let adjacentTagConfiguredFieldsOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionAdjacentTag()
+            .WithUnionAllowUnorderedTag()
+            .WithUnionTagName("type")
+            .WithUnionFieldsName("args")
+            .ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize AdjacentTag NamedFields alternative Fields`` () =
@@ -1989,11 +2018,11 @@ module Struct =
             JsonSerializer.Serialize(Bc("test", true), adjacentTagConfiguredFieldsOptions)
         )
 
-    let unwrapSingleFieldCasesOptions = JsonSerializerOptions()
-
-    unwrapSingleFieldCasesOptions.Converters.Add(
-        JsonFSharpConverter(JsonUnionEncoding.Default ||| JsonUnionEncoding.UnwrapSingleFieldCases)
-    )
+    let unwrapSingleFieldCasesOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionUnwrapSingleFieldCases()
+            .ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize unwrapped single-field cases`` () =
@@ -2017,8 +2046,11 @@ module Struct =
             JsonSerializer.Serialize(Bc("test", true), unwrapSingleFieldCasesOptions)
         )
 
-    let unwrapFieldlessTagsOptions = JsonSerializerOptions()
-    unwrapFieldlessTagsOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.UnwrapFieldlessTags))
+    let unwrapFieldlessTagsOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionUnwrapFieldlessTags()
+            .ToJsonSerializerOptions()
 
     [<Struct>]
     type S = { b: B }
@@ -2041,11 +2073,12 @@ module Struct =
             JsonSerializer.Serialize(Bc("test", true), unwrapFieldlessTagsOptions)
         )
 
-    let unwrapFieldlessTagsTagPolicyOptions = JsonSerializerOptions()
-
-    unwrapFieldlessTagsTagPolicyOptions.Converters.Add(
-        JsonFSharpConverter(JsonUnionEncoding.UnwrapFieldlessTags, unionTagNamingPolicy = JsonNamingPolicy.CamelCase)
-    )
+    let unwrapFieldlessTagsTagPolicyOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionUnwrapFieldlessTags()
+            .WithUnionTagNamingPolicy(JsonNamingPolicy.CamelCase)
+            .ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize UnwrapFieldlessTags with tag policy`` () =
@@ -2092,8 +2125,12 @@ module Struct =
             JsonSerializer.Serialize(NamedWithArgs 42, unwrapFieldlessTagsOptions)
         )
 
-    let nonUnwrapOptionOptions = JsonSerializerOptions()
-    nonUnwrapOptionOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.AdjacentTag))
+    let nonUnwrapOptionOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionAdjacentTag()
+            .WithUnwrapOption(false)
+            .ToJsonSerializerOptions()
 
     [<Fact>]
     let ``serialize non-UnwrapOption`` () =
@@ -2117,18 +2154,19 @@ module Struct =
             JsonSerializer.Deserialize("""{"vo":{"Case":"ValueNone"}}""", nonUnwrapOptionOptions)
         )
 
-    let ignoreNullOptions = JsonSerializerOptions(IgnoreNullValues = true)
-
-    ignoreNullOptions.Converters.Add(
-        JsonFSharpConverter(JsonUnionEncoding.InternalTag ||| JsonUnionEncoding.NamedFields)
-    )
+    let ignoreNullOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionInternalTag()
+            .WithUnionNamedFields()
+            .ToJsonSerializerOptions(IgnoreNullValues = true)
 
     let newIgnoreNullOptions =
-        JsonSerializerOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)
-
-    newIgnoreNullOptions.Converters.Add(
-        JsonFSharpConverter(JsonUnionEncoding.InternalTag ||| JsonUnionEncoding.NamedFields)
-    )
+        JsonFSharpOptions
+            .Default()
+            .WithUnionInternalTag()
+            .WithUnionNamedFields()
+            .ToJsonSerializerOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)
 
     [<AllowNullLiteral>]
     type Cls() =
@@ -2161,9 +2199,10 @@ module Struct =
         Assert.Equal("""{"Case":"Foo","x":1}""", actual)
 
     let propertyNamingPolicyOptions =
-        JsonSerializerOptions(PropertyNamingPolicy = JsonNamingPolicy.CamelCase)
-
-    propertyNamingPolicyOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.Untagged))
+        JsonFSharpOptions
+            .Default()
+            .WithUnionUntagged()
+            .ToJsonSerializerOptions(PropertyNamingPolicy = JsonNamingPolicy.CamelCase)
 
     [<Struct>]
     type CamelCase = CCA of CcFirst: int * CcSecond: string
@@ -2180,11 +2219,11 @@ module Struct =
         Assert.Equal("""{"ccFirst":1,"ccSecond":"a"}""", actual)
 
     let propertyNameCaseInsensitiveOptions =
-        JsonSerializerOptions(PropertyNameCaseInsensitive = true)
-
-    propertyNameCaseInsensitiveOptions.Converters.Add(
-        JsonFSharpConverter(JsonUnionEncoding.InternalTag ||| JsonUnionEncoding.NamedFields)
-    )
+        JsonFSharpOptions
+            .Default()
+            .WithUnionInternalTag()
+            .WithUnionNamedFields()
+            .ToJsonSerializerOptions(PropertyNameCaseInsensitive = true)
 
     [<Fact>]
     let ``deserialize with property case insensitive`` () =
@@ -2202,9 +2241,10 @@ module Struct =
         Assert.Equal("""{"Case":"CCA","CcFirst":1,"CcSecond":"a"}""", actual)
 
     let propertyNameCaseInsensitiveUntaggedOptions =
-        JsonSerializerOptions(PropertyNameCaseInsensitive = true)
-
-    propertyNameCaseInsensitiveUntaggedOptions.Converters.Add(JsonFSharpConverter(JsonUnionEncoding.Untagged))
+        JsonFSharpOptions
+            .Default()
+            .WithUnionUntagged()
+            .ToJsonSerializerOptions(PropertyNameCaseInsensitive = true)
 
     [<Fact>]
     let ``deserialize untagged with property case insensitive`` () =
@@ -2229,11 +2269,11 @@ module Struct =
     let ``serialize unwrapped single-case`` () =
         Assert.Equal("\"foo\"", JsonSerializer.Serialize(Unwrapped "foo", options))
 
-    let noNewtypeOptions = JsonSerializerOptions()
-
-    noNewtypeOptions.Converters.Add(
-        JsonFSharpConverter(JsonUnionEncoding.Default &&& ~~~JsonUnionEncoding.UnwrapSingleCaseUnions)
-    )
+    let noNewtypeOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionUnwrapSingleCaseUnions(false)
+            .ToJsonSerializerOptions()
 
     [<Fact>]
     let ``deserialize non-unwrapped single-case`` () =
@@ -2258,11 +2298,12 @@ module Struct =
 
         and [<Struct>] R = { x: int; y: float }
 
-        let adjacentTagOptions = JsonSerializerOptions()
-
-        adjacentTagOptions.Converters.Add(
-            JsonFSharpConverter(JsonUnionEncoding.AdjacentTag ||| JsonUnionEncoding.UnwrapRecordCases)
-        )
+        let adjacentTagOptions =
+            JsonFSharpOptions
+                .Default()
+                .WithUnionAdjacentTag()
+                .WithUnionUnwrapRecordCases()
+                .ToJsonSerializerOptions()
 
         [<Fact>]
         let ``serialize with AdjacentTag`` () =
@@ -2280,11 +2321,12 @@ module Struct =
                 JsonSerializer.Deserialize("""{"Case":"V","Fields":{"v":42}}""", adjacentTagOptions)
             Assert.Equal(V 42, actual)
 
-        let externalTagOptions = JsonSerializerOptions()
-
-        externalTagOptions.Converters.Add(
-            JsonFSharpConverter(JsonUnionEncoding.ExternalTag ||| JsonUnionEncoding.UnwrapRecordCases)
-        )
+        let externalTagOptions =
+            JsonFSharpOptions
+                .Default()
+                .WithUnionExternalTag()
+                .WithUnionUnwrapRecordCases()
+                .ToJsonSerializerOptions()
 
         [<Fact>]
         let ``serialize with externalTag`` () =
@@ -2301,11 +2343,12 @@ module Struct =
             let actual = JsonSerializer.Deserialize("""{"V":{"v":42}}""", externalTagOptions)
             Assert.Equal(V 42, actual)
 
-        let internalTagOptions = JsonSerializerOptions()
-
-        internalTagOptions.Converters.Add(
-            JsonFSharpConverter(JsonUnionEncoding.InternalTag ||| JsonUnionEncoding.UnwrapRecordCases)
-        )
+        let internalTagOptions =
+            JsonFSharpOptions
+                .Default()
+                .WithUnionInternalTag()
+                .WithUnionUnwrapRecordCases()
+                .ToJsonSerializerOptions()
 
         [<Fact>]
         let ``serialize with internalTag`` () =
@@ -2323,11 +2366,12 @@ module Struct =
                 JsonSerializer.Deserialize("""{"Case":"V","v":42}""", internalTagOptions)
             Assert.Equal(V 42, actual)
 
-        let untaggedOptions = JsonSerializerOptions()
-
-        untaggedOptions.Converters.Add(
-            JsonFSharpConverter(JsonUnionEncoding.Untagged ||| JsonUnionEncoding.UnwrapRecordCases)
-        )
+        let untaggedOptions =
+            JsonFSharpOptions
+                .Default()
+                .WithUnionUntagged()
+                .WithUnionUnwrapRecordCases()
+                .ToJsonSerializerOptions()
 
         [<Fact>]
         let ``serialize with untagged`` () =
@@ -2349,22 +2393,23 @@ module Struct =
 
     [<Fact>]
     let ``should not override tag name in attribute if AllowOverride = false`` () =
-        let o = JsonSerializerOptions()
-        o.Converters.Add(JsonFSharpConverter())
+        let o = JsonFSharpOptions.Default().ToJsonSerializerOptions()
         Assert.Equal("""{"Case":"A","Fields":[123,"abc"]}""", JsonSerializer.Serialize(Override.A(123, "abc"), o))
 
     [<Fact>]
     let ``should override tag name in attribute if AllowOverride = true`` () =
-        let o = JsonSerializerOptions()
-        o.Converters.Add(JsonFSharpConverter(allowOverride = true))
+        let o = JsonFSharpOptions.Default().WithAllowOverride().ToJsonSerializerOptions()
         Assert.Equal("""{"tag":"A","val":[123,"abc"]}""", JsonSerializer.Serialize(Override.A(123, "abc"), o))
 
     [<Fact>]
     let ``should not override JsonEncoding if not specified`` () =
-        let o = JsonSerializerOptions()
-        o.Converters.Add(
-            JsonFSharpConverter(JsonUnionEncoding.InternalTag ||| JsonUnionEncoding.NamedFields, allowOverride = true)
-        )
+        let o =
+            JsonFSharpOptions
+                .Default()
+                .WithUnionInternalTag()
+                .WithUnionNamedFields()
+                .WithAllowOverride()
+                .ToJsonSerializerOptions()
         Assert.Equal("""{"tag":"A","x":123,"y":"abc"}""", JsonSerializer.Serialize(Override.A(123, "abc"), o))
 
     [<JsonFSharpConverter(JsonUnionEncoding.InternalTag)>]
@@ -2373,38 +2418,40 @@ module Struct =
 
     [<Fact>]
     let ``should override JsonEncoding if specified`` () =
-        let o = JsonSerializerOptions()
-        o.Converters.Add(JsonFSharpConverter(allowOverride = true))
+        let o = JsonFSharpOptions.Default().WithAllowOverride().ToJsonSerializerOptions()
         Assert.Equal("""["A",123,"abc"]""", JsonSerializer.Serialize(Override2.A(123, "abc"), o))
 
     [<Fact>]
     let ``should apply explicit overrides if allowOverride = false`` () =
-        let o = JsonSerializerOptions()
-        o.Converters.Add(
-            JsonFSharpConverter(overrides = dict [ typeof<Override>, JsonFSharpOptions(JsonUnionEncoding.InternalTag) ])
-        )
+        let o =
+            JsonFSharpOptions
+                .Default()
+                .WithAllowOverride(false)
+                .WithOverrides(dict [ typeof<Override>, JsonFSharpOptions.Default().WithUnionInternalTag() ])
+                .ToJsonSerializerOptions()
         Assert.Equal("""["A",123,"abc"]""", JsonSerializer.Serialize(Override.A(123, "abc"), o))
 
     [<Fact>]
     let ``should apply explicit overrides if allowOverride = true`` () =
-        let o = JsonSerializerOptions()
-        o.Converters.Add(
-            JsonFSharpConverter(
-                allowOverride = true,
-                overrides = dict [ typeof<Override>, JsonFSharpOptions(JsonUnionEncoding.InternalTag) ]
-            )
-        )
+        let o =
+            JsonFSharpOptions
+                .Default()
+                .WithAllowOverride()
+                .WithOverrides(dict [ typeof<Override>, JsonFSharpOptions.Default().WithUnionInternalTag() ])
+                .ToJsonSerializerOptions()
         Assert.Equal("""["A",123,"abc"]""", JsonSerializer.Serialize(Override.A(123, "abc"), o))
 
     [<Fact>]
     let ``should apply explicit overrides inheriting JsonUnionEncoding`` () =
-        let o = JsonSerializerOptions()
-        o.Converters.Add(
-            JsonFSharpConverter(
-                JsonUnionEncoding.InternalTag ||| JsonUnionEncoding.NamedFields,
-                overrides = dict [ typeof<Override>, JsonFSharpOptions(unionTagName = "tag") ]
-            )
-        )
+        let o =
+            JsonFSharpOptions
+                .Default()
+                .WithUnionInternalTag()
+                .WithUnionNamedFields()
+                .WithOverrides(
+                    dict [ typeof<Override>, JsonFSharpOptions.InheritUnionEncoding().WithUnionTagName("tag") ]
+                )
+                .ToJsonSerializerOptions()
         Assert.Equal("""{"tag":"A","x":123,"y":"abc"}""", JsonSerializer.Serialize(Override.A(123, "abc"), o))
 
     [<Struct>]
@@ -2422,15 +2469,14 @@ module Struct =
     [<Struct>]
     type NamedAfterTypesE = NTE of string * string
 
-    let namedAfterTypesOptions = JsonSerializerOptions()
-
-    namedAfterTypesOptions.Converters.Add(
-        JsonFSharpConverter(
-            JsonUnionEncoding.InternalTag
-            ||| JsonUnionEncoding.NamedFields
-            ||| JsonUnionEncoding.UnionFieldNamesFromTypes
-        )
-    )
+    let namedAfterTypesOptions =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionInternalTag()
+            .WithUnionNamedFields()
+            .WithUnionFieldNamesFromTypes()
+            .WithUnionUnwrapSingleCaseUnions(false)
+            .ToJsonSerializerOptions()
 
     [<Fact>]
     let ``serialize UnionFieldNamesFromTypes`` () =
@@ -2466,16 +2512,15 @@ module Struct =
             JsonSerializer.Deserialize("""{"Case":"NTE","String1":"123","String2":"test"}""", namedAfterTypesOptions)
         )
 
-    let namedAfterTypesOptionsWithNamingPolicy = JsonSerializerOptions()
-
-    namedAfterTypesOptionsWithNamingPolicy.Converters.Add(
-        JsonFSharpConverter(
-            JsonUnionEncoding.InternalTag
-            ||| JsonUnionEncoding.NamedFields
-            ||| JsonUnionEncoding.UnionFieldNamesFromTypes,
-            unionFieldNamingPolicy = JsonNamingPolicy.CamelCase
-        )
-    )
+    let namedAfterTypesOptionsWithNamingPolicy =
+        JsonFSharpOptions
+            .Default()
+            .WithUnionInternalTag()
+            .WithUnionNamedFields()
+            .WithUnionFieldNamesFromTypes()
+            .WithUnionFieldNamingPolicy(JsonNamingPolicy.CamelCase)
+            .WithUnionUnwrapSingleCaseUnions(false)
+            .ToJsonSerializerOptions()
 
     [<Fact>]
     let ``serialize UnionFieldNamesFromTypes with unionFieldNamingPolicy`` () =


### PR DESCRIPTION
This PR introduces a new fluent syntax to define the options of the converter.

```fsharp
// New syntax:
let options =
    JsonFSharpOptions.Default()
        .WithUnionAdjacentTag()
        .WithUnionNamedFields()
        .WithUnwrapOption(false)
        .WithUnionTagName("type")
        .ToJsonSerializerOptions()

// Current syntax equivalent:
let options = JsonSerializerOptions()
JsonFSharpConverter(
    (JsonUnionEncoding.AdjacentTag
    ||| JsonUnionEncoding.NamedFields)
    &&& ~~~JsonUnionEncoding.UnwrapOption,
    unionTagName = "type")
|> options.Converters.Add
```

New API:

* Initializer methods:
    *  `.Default()`, `.NewtonsoftLike()`, `.ThothLike()`, `.FSharpLuLike()` that create options with the corresponding `JsonUnionEncoding`.
* Fluent option methods:
    * A method `.WithUnionFoo(?bool)` for every enum case `JsonUnionEncoding.Foo`;
    * A method `.WithFoo(value)` for every optional argument `foo` of the `JsonFSharpConverter` constructor.
* Build methods:
    * `.ToJsonSerializerOptions()` creates a `JsonSerializerOptions` with an F# converter;
    * `.AddToJsonSerializerOptions(options)` adds the F# converter to an existing `JsonSerializerOptions`, useful to integrate with ASP.NET Core, Giraffe, or other libraries.

Advantages:

* More uniform syntax for the various options, instead of having some passed as enum and others as optional arguments.
* Better binary compatibility: adding an optional argument to the `JsonFSharpConverter` constructor is binary-breaking (see #132), whereas adding a fluent method isn't.
* Allows creating a `JsonSerializerOptions` in a single expression, without having to create it and then mutate it. Especially useful when creating global options in a module.
* Easier to create a base of common options and then alter them slightly for overrides:
    ```fsharp
    let commonOptions =
        JsonFSharpOptions.Default()
            .WithUnionAdjacentTag()
            .WithUnionNamedFields()

    let options =
        commonOptions
            .WithOverrides(dict [
                typeof<MyCustomType>, commonOptions.WithUnionTagName("type")
                typeof<OtherCustomType>, commonOptions.WithUnionUnwrapSingleFieldCases()
            ])
            .ToJsonSerializerOptions()
    ```

Unresolved questions:
* The fluent syntax looks very C#-ish, even though it works perfectly fine in F#. Should we also add a more F#-ish syntax with module functions?
    ```fsharp
    let options =
        JsonFSharpOptions.Default()
        |> JsonFSharpOptions.unionAdjacentTag
        |> JsonFSharpOptions.unionNamedFields true
        |> JsonFSharpOptions.unwrapOption false
        |> JsonFSharpOptions.unionTagName "type"
        |> JsonFSharpOptions.toJsonSerializerOptions
    ```
* What about `JsonFSharpConverterAttribute`? Since it's an attribute, it can't be fluent. Perhaps it should have settable properties that do the same thing as corresponding fluent methods, eg:
    ```fsharp
    [<JsonFSharpConverter(UnionNamedFields = true, UnwrapOption = false)>]
    type Foo = // ...
    ```
