### PR TITLE
Add SkippableOptionFields that allows skipping option and voption fields

### DIFF
--- a/src/FSharp.SystemTextJson/All.fs
+++ b/src/FSharp.SystemTextJson/All.fs
@@ -129,6 +129,8 @@ type JsonFSharpConverterAttribute(fsOptions: JsonFSharpOptions) =
         with set v = fsOptions <- fsOptions.WithUnionAllowUnorderedTag(v)
     member _.UnionFieldNamesFromTypes
         with set v = fsOptions <- fsOptions.WithUnionFieldNamesFromTypes(v)
+    member _.SkippableOptionFields
+        with set v = fsOptions <- fsOptions.WithSkippableOptionFields(v)
 
     new() = JsonFSharpConverterAttribute(JsonFSharpOptions())
 

--- a/src/FSharp.SystemTextJson/Helpers.fs
+++ b/src/FSharp.SystemTextJson/Helpers.fs
@@ -3,7 +3,6 @@
 #nowarn "44" // JsonSerializerOptions.IgnoreNullValues is obsolete for users but still relevant for converters.
 
 open System
-open System.Collections.Generic
 open System.Reflection
 open System.Text.Json
 open System.Text.Json.Serialization
@@ -39,14 +38,20 @@ let isNullableUnion (ty: Type) =
         x.Flags.HasFlag(CompilationRepresentationFlags.UseNullAsTrueValue)
     )
 
-let isSkippableType (ty: Type) =
-    ty.IsGenericType && ty.GetGenericTypeDefinition() = typedefof<Skippable<_>>
+let isSkippableType (fsOptions: JsonFSharpOptionsRecord) (ty: Type) =
+    if ty.IsGenericType then
+        let genTy = ty.GetGenericTypeDefinition()
+        genTy = typedefof<Skippable<_>>
+        || (fsOptions.SkippableOptionFields
+            && (genTy = typedefof<option<_>> || genTy = typedefof<voption<_>>))
+    else
+        false
 
 let isValueOptionType (ty: Type) =
     ty.IsGenericType && ty.GetGenericTypeDefinition() = typedefof<ValueOption<_>>
 
-let isSkip (ty: Type) =
-    if isSkippableType ty then
+let isSkip (fsOptions: JsonFSharpOptionsRecord) (ty: Type) =
+    if isSkippableType fsOptions ty then
         let getTag = FSharpValue.PreComputeUnionTagReader(ty)
         fun x -> getTag x = 0
     else
@@ -88,7 +93,7 @@ let rec tryGetNullValue (fsOptions: JsonFSharpOptionsRecord) (ty: Type) : obj vo
     elif fsOptions.UnionEncoding.HasFlag JsonUnionEncoding.UnwrapOption
          && isValueOptionType ty then
         ValueSome(FSharpValue.MakeUnion(FSharpType.GetUnionCases(ty, true)[0], [||], true))
-    elif isSkippableType ty then
+    elif isSkippableType fsOptions ty then
         tryGetNullValue fsOptions (ty.GetGenericArguments()[0])
         |> ValueOption.map (fun x -> FSharpValue.MakeUnion(FSharpType.GetUnionCases(ty, true)[1], [| x |], true))
     elif

--- a/src/FSharp.SystemTextJson/Options.fs
+++ b/src/FSharp.SystemTextJson/Options.fs
@@ -158,6 +158,7 @@ type internal JsonFSharpOptionsRecord =
       UnionTagCaseInsensitive: bool
       AllowNullFields: bool
       IncludeRecordProperties: bool
+      SkippableOptionFields: bool
       Types: JsonFSharpTypes
       AllowOverride: bool
       Overrides: JsonFSharpOptions -> IDictionary<Type, JsonFSharpOptions> }
@@ -190,6 +191,7 @@ and JsonFSharpOptions internal (options: JsonFSharpOptionsRecord) =
               UnionTagCaseInsensitive = unionTagCaseInsensitive
               AllowNullFields = allowNullFields
               IncludeRecordProperties = includeRecordProperties
+              SkippableOptionFields = false
               Types = types
               AllowOverride = allowOverride
               Overrides = emptyOverrides }
@@ -228,6 +230,8 @@ and JsonFSharpOptions internal (options: JsonFSharpOptionsRecord) =
 
     member _.IncludeRecordProperties = options.IncludeRecordProperties
 
+    member _.SkippableOptionFields = options.SkippableOptionFields
+
     member _.Types = options.Types
 
     member _.AllowOverride = options.AllowOverride
@@ -257,6 +261,17 @@ and JsonFSharpOptions internal (options: JsonFSharpOptionsRecord) =
 
     member _.WithIncludeRecordProperties([<Optional; DefaultParameterValue true>] includeRecordProperties) =
         JsonFSharpOptions({ options with IncludeRecordProperties = includeRecordProperties })
+
+    member _.WithSkippableOptionFields([<Optional; DefaultParameterValue true>] skippableOptionFields) =
+        JsonFSharpOptions(
+            { options with
+                SkippableOptionFields = skippableOptionFields
+                UnionEncoding =
+                    if skippableOptionFields then
+                        options.UnionEncoding ||| JsonUnionEncoding.UnwrapOption
+                    else
+                        options.UnionEncoding }
+        )
 
     member _.WithTypes(types) =
         JsonFSharpOptions({ options with Types = types })

--- a/src/FSharp.SystemTextJson/Record.fs
+++ b/src/FSharp.SystemTextJson/Record.fs
@@ -79,7 +79,7 @@ type JsonRecordConverter<'T> internal (options: JsonSerializerOptions, fsOptions
                 p.GetCustomAttributes(typeof<JsonIgnoreAttribute>, true) |> Array.isEmpty |> not
             let nullValue = tryGetNullValue fsOptions p.PropertyType
             let canBeSkipped =
-                ignore || ignoreNullValues options || isSkippableType p.PropertyType
+                ignore || ignoreNullValues options || isSkippableType fsOptions p.PropertyType
             let read =
                 let m = p.GetGetMethod()
                 fun o -> m.Invoke(o, Array.empty)
@@ -88,7 +88,7 @@ type JsonRecordConverter<'T> internal (options: JsonSerializerOptions, fsOptions
               Ignore = ignore
               NullValue = nullValue
               MustBePresent = not canBeSkipped
-              IsSkip = isSkip p.PropertyType
+              IsSkip = isSkip fsOptions p.PropertyType
               Read = read
               WriteOrder =
                 match fieldOrderIndices with
@@ -119,7 +119,7 @@ type JsonRecordConverter<'T> internal (options: JsonSerializerOptions, fsOptions
         let arr = Array.zeroCreate fieldCount
         fieldProps
         |> Array.iteri (fun i field ->
-            if isSkippableType field.Type || isValueOptionType field.Type then
+            if isSkippableType fsOptions field.Type || isValueOptionType field.Type then
                 let case = FSharpType.GetUnionCases(field.Type)[0]
                 arr[i] <- FSharpValue.MakeUnion(case, [||])
         )

--- a/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
@@ -74,15 +74,19 @@ module NonStruct =
             Assert.Equal("Missing field for record type Tests.Record+NonStruct+B: by", e.Message)
 
     type SomeSearchApi =
-        { filter: string option
+        { filter: string voption
           limit: int option
           offset: int option }
 
-    let ``allow omitting fields that are optional`` () =
-        let result = JsonSerializer.Deserialize<SomeSearchApi>("""{}""", options)
-        Assert.Equal(result, { filter = None; limit = None; offset = None })
-        let result = JsonSerializer.Deserialize<SomeSearchApi>("""{"limit": 50}""", options)
-        Assert.Equal(result, { filter = None; limit = Some 50; offset = None })
+    [<Fact>]
+    let ``dont allow omitting fields that are optional`` () =
+        Assert.Throws<JsonException>(fun () -> JsonSerializer.Deserialize<SomeSearchApi>("""{}""", options) |> ignore)
+        |> ignore
+        Assert.Throws<JsonException>(fun () ->
+            JsonSerializer.Deserialize<SomeSearchApi>("""{"limit": 50}""", options)
+            |> ignore
+        )
+        |> ignore
 
     [<Fact>]
     let allowNullFields () =
@@ -469,15 +473,19 @@ module Struct =
 
     [<Struct>]
     type SomeSearchApi =
-        { filter: string option
+        { filter: string voption
           limit: int option
           offset: int option }
 
-    let ``allow omitting fields that are optional`` () =
-        let result = JsonSerializer.Deserialize<SomeSearchApi>("""{}""", options)
-        Assert.Equal(result, { filter = None; limit = None; offset = None })
-        let result = JsonSerializer.Deserialize<SomeSearchApi>("""{"limit": 50}""", options)
-        Assert.Equal(result, { filter = None; limit = Some 50; offset = None })
+    [<Fact>]
+    let ``dont allow omitting fields that are optional`` () =
+        Assert.Throws<JsonException>(fun () -> JsonSerializer.Deserialize<SomeSearchApi>("""{}""", options) |> ignore)
+        |> ignore
+        Assert.Throws<JsonException>(fun () ->
+            JsonSerializer.Deserialize<SomeSearchApi>("""{"limit": 50}""", options)
+            |> ignore
+        )
+        |> ignore
 
     [<Fact>]
     let allowNullFields () =

--- a/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
@@ -94,7 +94,7 @@ module NonStruct =
         let actual = JsonSerializer.Deserialize("""{"bx":1,"by":null}""", options)
         Assert.Equal({ bx = 1; by = null }, actual)
 
-    type S =
+    type Sk =
         { sa: int
           sb: Skippable<int>
           sc: Skippable<int option>
@@ -143,6 +143,69 @@ module NonStruct =
                   sb = Include 2
                   sc = Include(Some 3)
                   sd = Include(ValueSome 4) },
+                options
+            )
+        Assert.Equal("""{"sa":1,"sb":2,"sc":3,"sd":4}""", actual)
+
+    type SkO =
+        { sa: int
+          sb: int option
+          sc: int option voption
+          sd: int voption option }
+
+    [<Fact>]
+    let ``deserialize skippable union field`` () =
+        let options =
+            JsonFSharpOptions
+                .Default()
+                .WithSkippableOptionFields()
+                .ToJsonSerializerOptions()
+        let actual = JsonSerializer.Deserialize("""{"sa":1}""", options)
+        Assert.Equal({ sa = 1; sb = None; sc = ValueNone; sd = None }, actual)
+        let actual =
+            JsonSerializer.Deserialize("""{"sa":1,"sb":2,"sc":null,"sd":null}""", options)
+        Assert.Equal(
+            { sa = 1
+              sb = Some 2
+              sc = ValueSome None
+              sd = Some ValueNone },
+            actual
+        )
+        let actual =
+            JsonSerializer.Deserialize("""{"sa":1,"sb":2,"sc":3,"sd":4}""", options)
+        Assert.Equal(
+            { sa = 1
+              sb = Some 2
+              sc = ValueSome(Some 3)
+              sd = Some(ValueSome 4) },
+            actual
+        )
+
+    [<Fact>]
+    let ``serialize skippable union field`` () =
+        let options =
+            JsonFSharpOptions
+                .Default()
+                .WithSkippableOptionFields()
+                .ToJsonSerializerOptions()
+        let actual =
+            JsonSerializer.Serialize({ sa = 1; sb = None; sc = ValueNone; sd = None }, options)
+        Assert.Equal("""{"sa":1}""", actual)
+        let actual =
+            JsonSerializer.Serialize(
+                { sa = 1
+                  sb = Some 2
+                  sc = ValueSome None
+                  sd = Some ValueNone },
+                options
+            )
+        Assert.Equal("""{"sa":1,"sb":2,"sc":null,"sd":null}""", actual)
+        let actual =
+            JsonSerializer.Serialize(
+                { sa = 1
+                  sb = Some 2
+                  sc = ValueSome(Some 3)
+                  sd = Some(ValueSome 4) },
                 options
             )
         Assert.Equal("""{"sa":1,"sb":2,"sc":3,"sd":4}""", actual)
@@ -494,7 +557,7 @@ module Struct =
         Assert.Equal({ bx = 1; by = null }, actual)
 
     [<Struct>]
-    type S =
+    type Sk =
         { sa: int
           sb: Skippable<int>
           sc: Skippable<int option>
@@ -543,6 +606,70 @@ module Struct =
                   sb = Include 2
                   sc = Include(Some 3)
                   sd = Include(ValueSome 4) },
+                options
+            )
+        Assert.Equal("""{"sa":1,"sb":2,"sc":3,"sd":4}""", actual)
+
+    [<Struct>]
+    type SkO =
+        { sa: int
+          sb: int option
+          sc: int option voption
+          sd: int voption option }
+
+    [<Fact>]
+    let ``deserialize skippable union field`` () =
+        let options =
+            JsonFSharpOptions
+                .Default()
+                .WithSkippableOptionFields()
+                .ToJsonSerializerOptions()
+        let actual = JsonSerializer.Deserialize("""{"sa":1}""", options)
+        Assert.Equal({ sa = 1; sb = None; sc = ValueNone; sd = None }, actual)
+        let actual =
+            JsonSerializer.Deserialize("""{"sa":1,"sb":2,"sc":null,"sd":null}""", options)
+        Assert.Equal(
+            { sa = 1
+              sb = Some 2
+              sc = ValueSome None
+              sd = Some ValueNone },
+            actual
+        )
+        let actual =
+            JsonSerializer.Deserialize("""{"sa":1,"sb":2,"sc":3,"sd":4}""", options)
+        Assert.Equal(
+            { sa = 1
+              sb = Some 2
+              sc = ValueSome(Some 3)
+              sd = Some(ValueSome 4) },
+            actual
+        )
+
+    [<Fact>]
+    let ``serialize skippable union field`` () =
+        let options =
+            JsonFSharpOptions
+                .Default()
+                .WithSkippableOptionFields()
+                .ToJsonSerializerOptions()
+        let actual =
+            JsonSerializer.Serialize({ sa = 1; sb = None; sc = ValueNone; sd = None }, options)
+        Assert.Equal("""{"sa":1}""", actual)
+        let actual =
+            JsonSerializer.Serialize(
+                { sa = 1
+                  sb = Some 2
+                  sc = ValueSome None
+                  sd = Some ValueNone },
+                options
+            )
+        Assert.Equal("""{"sa":1,"sb":2,"sc":null,"sd":null}""", actual)
+        let actual =
+            JsonSerializer.Serialize(
+                { sa = 1
+                  sb = Some 2
+                  sc = ValueSome(Some 3)
+                  sd = Some(ValueSome 4) },
                 options
             )
         Assert.Equal("""{"sa":1,"sb":2,"sc":3,"sd":4}""", actual)

--- a/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
@@ -566,6 +566,50 @@ module NonStruct =
             )
         )
 
+    type SkO = SkO of a: int * b: int option * c: int option voption * d: int voption option
+
+    [<Fact>]
+    let ``deserialize InternalTag NamedFields with Skippable options`` () =
+        let options =
+            JsonFSharpOptions
+                .Default()
+                .WithUnionInternalTag()
+                .WithUnionNamedFields()
+                .WithSkippableOptionFields()
+                .ToJsonSerializerOptions()
+        Assert.Equal(SkO(1, None, ValueNone, None), JsonSerializer.Deserialize("""{"Case":"SkO","a":1}""", options))
+        Assert.Equal(
+            SkO(1, Some 2, ValueSome None, Some ValueNone),
+            JsonSerializer.Deserialize("""{"Case":"SkO","a":1,"b":2,"c":null,"d":null}""", options)
+        )
+        Assert.Equal(
+            SkO(1, Some 2, ValueSome(Some 3), Some(ValueSome 4)),
+            JsonSerializer.Deserialize("""{"Case":"SkO","a":1,"b":2,"c":3,"d":4}""", options)
+        )
+        Assert.Equal(
+            SkO(1, Some 2, ValueSome(Some 3), Some(ValueSome 4)),
+            JsonSerializer.Deserialize("""{"a":1,"b":2,"Case":"SkO","c":3,"d":4}""", options)
+        )
+
+    [<Fact>]
+    let ``serialize InternalTag NamedFields with Skippable options`` () =
+        let options =
+            JsonFSharpOptions
+                .Default()
+                .WithUnionInternalTag()
+                .WithUnionNamedFields()
+                .WithSkippableOptionFields()
+                .ToJsonSerializerOptions()
+        Assert.Equal("""{"Case":"SkO","a":1}""", JsonSerializer.Serialize(SkO(1, None, ValueNone, None), options))
+        Assert.Equal(
+            """{"Case":"SkO","a":1,"b":2,"c":null,"d":null}""",
+            JsonSerializer.Serialize(SkO(1, Some 2, ValueSome None, Some ValueNone), options)
+        )
+        Assert.Equal(
+            """{"Case":"SkO","a":1,"b":2,"c":3,"d":4}""",
+            JsonSerializer.Serialize(SkO(1, Some 2, ValueSome(Some 3), Some(ValueSome 4)), options)
+        )
+
     let internalTagNamedFieldsTagPolicyOptions =
         JsonFSharpOptions
             .Default()
@@ -1882,6 +1926,51 @@ module Struct =
                 S(1, Include 2, Include(Some 3), Include(ValueSome 4)),
                 internalTagNamedFieldsOptions
             )
+        )
+
+    [<Struct>]
+    type SkO = SkO of a: int * b: int option * c: int option voption * d: int voption option
+
+    [<Fact>]
+    let ``deserialize InternalTag NamedFields with Skippable options`` () =
+        let options =
+            JsonFSharpOptions
+                .Default()
+                .WithUnionInternalTag()
+                .WithUnionNamedFields()
+                .WithSkippableOptionFields()
+                .ToJsonSerializerOptions()
+        Assert.Equal(SkO(1, None, ValueNone, None), JsonSerializer.Deserialize("""{"Case":"SkO","a":1}""", options))
+        Assert.Equal(
+            SkO(1, Some 2, ValueSome None, Some ValueNone),
+            JsonSerializer.Deserialize("""{"Case":"SkO","a":1,"b":2,"c":null,"d":null}""", options)
+        )
+        Assert.Equal(
+            SkO(1, Some 2, ValueSome(Some 3), Some(ValueSome 4)),
+            JsonSerializer.Deserialize("""{"Case":"SkO","a":1,"b":2,"c":3,"d":4}""", options)
+        )
+        Assert.Equal(
+            SkO(1, Some 2, ValueSome(Some 3), Some(ValueSome 4)),
+            JsonSerializer.Deserialize("""{"a":1,"b":2,"Case":"SkO","c":3,"d":4}""", options)
+        )
+
+    [<Fact>]
+    let ``serialize InternalTag NamedFields with Skippable options`` () =
+        let options =
+            JsonFSharpOptions
+                .Default()
+                .WithUnionInternalTag()
+                .WithUnionNamedFields()
+                .WithSkippableOptionFields()
+                .ToJsonSerializerOptions()
+        Assert.Equal("""{"Case":"SkO","a":1}""", JsonSerializer.Serialize(SkO(1, None, ValueNone, None), options))
+        Assert.Equal(
+            """{"Case":"SkO","a":1,"b":2,"c":null,"d":null}""",
+            JsonSerializer.Serialize(SkO(1, Some 2, ValueSome None, Some ValueNone), options)
+        )
+        Assert.Equal(
+            """{"Case":"SkO","a":1,"b":2,"c":3,"d":4}""",
+            JsonSerializer.Serialize(SkO(1, Some 2, ValueSome(Some 3), Some(ValueSome 4)), options)
         )
 
     let internalTagNamedFieldsTagPolicyOptions =


### PR DESCRIPTION
This adds a new option `.WithSkippableOptionFields()` that essentially restores the pre-1.0 behavior of fields of type `option` and `voption`: during deserialization, a missing field is deserialized as `None` / `ValueNone`.