### PR TITLE
Fix #151: do not wrap null with Some

### DIFF
--- a/src/FSharp.SystemTextJson/Record.fs
+++ b/src/FSharp.SystemTextJson/Record.fs
@@ -68,7 +68,7 @@ type private RecordField
         | ValueNone -> i
 
     member _.Deserialize(reader: byref<Utf8JsonReader>, recordType: Type) =
-        if reader.TokenType = JsonTokenType.Null && not isSkippableType then
+        if reader.TokenType = JsonTokenType.Null then
             match nullValue with
             | ValueSome v -> v
             | ValueNone ->

--- a/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
@@ -167,8 +167,8 @@ module NonStruct =
         Assert.Equal(
             { sa = 1
               sb = Some 2
-              sc = ValueSome None
-              sd = Some ValueNone },
+              sc = ValueNone
+              sd = None },
             actual
         )
         let actual =
@@ -631,8 +631,8 @@ module Struct =
         Assert.Equal(
             { sa = 1
               sb = Some 2
-              sc = ValueSome None
-              sd = Some ValueNone },
+              sc = ValueNone
+              sd = None },
             actual
         )
         let actual =

--- a/tests/FSharp.SystemTextJson.Tests/Test.Regression.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Regression.fs
@@ -99,3 +99,14 @@ let ``regression #123`` () =
         { FirstName = "yarr"; LastName = None; age = 5 },
         JsonSerializer.Deserialize<Person>("""{"FirstName": "yarr", "age": 5 }""", skipOptions2)
     )
+
+[<Fact>]
+let ``regression #151`` () =  
+    let skippableOptionFieldsOptions =
+        JsonFSharpOptions.Default()
+            .WithSkippableOptionFields()
+            .ToJsonSerializerOptions()                           
+    
+    let person = JsonSerializer.Deserialize<{| FirstName: string option |}>("""{"FirstName":null}""", skippableOptionFieldsOptions)
+    
+    Assert.Equal({| FirstName = None |}, person)


### PR DESCRIPTION
Fixes #151

I have changed 2 existing tests because 

- I think (with my limited knowledge in the subject) skipping a skippable field and explicitly setting it to null should have exactly the same effect
- they failed after my change 😝

`type Person = { FirstName: string; LastName: string voption option }`

`{ "FirstName": "Marie" }` and `{ "FirstName": "Marie", "LastName": null }`

should both result to 

`{ FirstName = "Marie"; LastName = None }` and not `Some ValueNone` (outer most Option should be None)