### PR TITLE
Explicitly handle null values to throw an exception

### DIFF
--- a/src/FSharp.SystemTextJson/Record.fs
+++ b/src/FSharp.SystemTextJson/Record.fs
@@ -237,6 +237,8 @@ type JsonRecordConverter<'T> internal (options: JsonSerializerOptions, fsOptions
         writer.WriteStartObject()
         this.WriteRestOfObject(writer, value, options)
 
+    override this.HandleNull = true
+
     member internal _.WriteRestOfObject(writer, value, options) =
         let values = dector value
         for struct (i, p) in writeOrderedFieldProps do

--- a/src/FSharp.SystemTextJson/Tuple.fs
+++ b/src/FSharp.SystemTextJson/Tuple.fs
@@ -41,6 +41,8 @@ type JsonTupleConverter<'T> internal (fsOptions) =
             JsonSerializer.Serialize(writer, values[i], fieldProps[i].Type, options)
         writer.WriteEndArray()
 
+    override _.HandleNull = true
+
     new(fsOptions: JsonFSharpOptions) = JsonTupleConverter<'T>(fsOptions.Record)
 
 type JsonTupleConverter(fsOptions) =

--- a/src/FSharp.SystemTextJson/Union.fs
+++ b/src/FSharp.SystemTextJson/Union.fs
@@ -693,6 +693,8 @@ type JsonUnionConverter<'T>
                 | UntaggedBit -> writeUntagged writer case value options
                 | _ -> failf "Invalid union encoding: %A" fsOptions.UnionEncoding
 
+    override _.HandleNull = true
+
     new(options, fsOptions: JsonFSharpOptions, cases) = JsonUnionConverter<'T>(options, fsOptions.Record, cases)
 
 type JsonSkippableConverter<'T>() =

--- a/tests/FSharp.SystemTextJson.Tests/Test.Collection.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Collection.fs
@@ -227,3 +227,25 @@ let ``serialize struct 8-tuple`` (a, b, c, d, e, f, g, h as t: struct (int * int
     let expected = sprintf "[%i,%i,%i,%i,%i,%i,%i,%i]" a b c d e f g h
     let actual = JsonSerializer.Serialize(t, options)
     Assert.Equal(expected, actual)
+
+module NullCollections =
+
+    [<Fact>]
+    let ``disallow null list`` () =
+        Assert.Throws<JsonException>(fun () -> JsonSerializer.Deserialize<int list>("null", options) |> ignore)
+        |> ignore
+
+    [<Fact>]
+    let ``disallow null set`` () =
+        Assert.Throws<JsonException>(fun () -> JsonSerializer.Deserialize<Set<int>>("null", options) |> ignore)
+        |> ignore
+
+    [<Fact>]
+    let ``disallow null string maps`` () =
+        Assert.Throws<JsonException>(fun () -> JsonSerializer.Deserialize<Map<string, int>>("null", options) |> ignore)
+        |> ignore
+
+    [<Fact>]
+    let ``disallow null non-string maps`` () =
+        Assert.Throws<JsonException>(fun () -> JsonSerializer.Deserialize<Map<int, int>>("null", options) |> ignore)
+        |> ignore

--- a/tests/FSharp.SystemTextJson.Tests/Test.Collection.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Collection.fs
@@ -249,3 +249,30 @@ module NullCollections =
     let ``disallow null non-string maps`` () =
         Assert.Throws<JsonException>(fun () -> JsonSerializer.Deserialize<Map<int, int>>("null", options) |> ignore)
         |> ignore
+
+    [<Fact>]
+    let ``disallow null 2-tuple`` () =
+        Assert.Throws<JsonException>(fun () -> JsonSerializer.Deserialize<int * int>("null", options) |> ignore)
+        |> ignore
+
+    [<Fact>]
+    let ``disallow null 8-tuple`` () =
+        Assert.Throws<JsonException>(fun () ->
+            JsonSerializer.Deserialize<int * int * int * int * int * int * int * int>("null", options)
+            |> ignore
+        )
+        |> ignore
+
+    [<Fact>]
+    let ``disallow null struct 2-tuple`` () =
+        Assert.Throws<JsonException>(fun () -> JsonSerializer.Deserialize<struct (int * int)>("null", options) |> ignore
+        )
+        |> ignore
+
+    [<Fact>]
+    let ``disallow null struct 8-tuple`` () =
+        Assert.Throws<JsonException>(fun () ->
+            JsonSerializer.Deserialize<struct (int * int * int * int * int * int * int * int)>("null", options)
+            |> ignore
+        )
+        |> ignore

--- a/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
@@ -33,6 +33,11 @@ module NonStruct =
         let actual = JsonSerializer.Serialize({ bx = 1; by = "b" }, options)
         Assert.Equal("""{"bx":1,"by":"b"}""", actual)
 
+    [<Fact>]
+    let ``disallow null records`` () =
+        Assert.Throws<JsonException>(fun () -> JsonSerializer.Deserialize<B>("null", options) |> ignore)
+        |> ignore
+
     type internal Internal = { ix: int }
 
     [<Fact>]
@@ -491,6 +496,11 @@ module Struct =
     let ``serialize via options`` () =
         let actual = JsonSerializer.Serialize({ bx = 1; by = "b" }, options)
         Assert.Equal("""{"bx":1,"by":"b"}""", actual)
+
+    [<Fact>]
+    let ``disallow null records`` () =
+        Assert.Throws<JsonException>(fun () -> JsonSerializer.Deserialize<B>("null", options) |> ignore)
+        |> ignore
 
     [<Struct>]
     type internal Internal = { ix: int }

--- a/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
@@ -52,6 +52,11 @@ module NonStruct =
         Assert.Equal("""{"Case":"Bc","Fields":["test",true]}""", JsonSerializer.Serialize(Bc("test", true), options))
 
     [<Fact>]
+    let ``disallow null unions`` () =
+        Assert.Throws<JsonException>(fun () -> JsonSerializer.Deserialize<B>("null", options) |> ignore)
+        |> ignore
+
+    [<Fact>]
     let ``not fill in nulls`` () =
         try
             JsonSerializer.Deserialize<B>("""{"Case":"Bc","Fields":[null,true]}""", options)
@@ -1405,6 +1410,11 @@ module Struct =
         Assert.Equal("""{"Case":"Ba"}""", JsonSerializer.Serialize(Ba, options))
         Assert.Equal("""{"Case":"Bb","Fields":[32]}""", JsonSerializer.Serialize(Bb 32, options))
         Assert.Equal("""{"Case":"Bc","Fields":["test",true]}""", JsonSerializer.Serialize(Bc("test", true), options))
+
+    [<Fact>]
+    let ``disallow null unions`` () =
+        Assert.Throws<JsonException>(fun () -> JsonSerializer.Deserialize<B>("null", options) |> ignore)
+        |> ignore
 
     [<Fact>]
     let ``not fill in nulls`` () =


### PR DESCRIPTION
Fixes #158.

Throw a `JsonException` when trying to deserialize `null` into the following types:

* [x] Unions (unless explicitly allowed, eg. with `CompilationRepresentationFlags.UseNullAsTrueValue`)
* [x] Records
* [x] Tuples
* [x] Lists
* [x] Sets
* [x] Maps