### PR TITLE
Add failing unit test demonstrating an issue

### DIFF
--- a/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
@@ -15,6 +15,15 @@ module NonStruct =
         Assert.Equal({ ax = 1; ay = "b" }, actual)
 
     [<Fact>]
+    let ``deserialize empty record with ignore-null-values on`` () =
+        let options = JsonSerializerOptions(DefaultIgnoreCondition = Serialization.JsonIgnoreCondition.WhenWritingNull)
+        try
+            JsonSerializer.Deserialize<A>("{}", options) |> ignore
+        with
+            | :? System.NullReferenceException -> failwith "Unexpected NRE."
+            | ex when ex.Message.Contains("Missing field for record type") -> () // It's expected to fail since the record requires its fields to be initialized.
+
+    [<Fact>]
     let ``serialize via explicit converter`` () =
         let actual = JsonSerializer.Serialize { ax = 1; ay = "b" }
         Assert.Equal("""{"ax":1,"ay":"b"}""", actual)


### PR DESCRIPTION
The record converter throws a NRE when trying to deserialize an empty json object, if the ignore nulls option is enabled.