### PR TITLE
fix #164: NRE on deserializing missing field with JsonIgnoreCondition.WhenWritingNull

### DIFF
--- a/src/FSharp.SystemTextJson/Record.fs
+++ b/src/FSharp.SystemTextJson/Record.fs
@@ -27,7 +27,8 @@ type private RecordField
 
     let isSkippableType = isSkippableType fsOptions p.PropertyType
 
-    let canBeSkipped = ignore || (ignoreNullValues options && nullValue.IsSome) || isSkippableType
+    let canBeSkipped =
+        ignore || (ignoreNullValues options && nullValue.IsSome) || isSkippableType
 
     let read =
         let m = p.GetGetMethod()

--- a/src/FSharp.SystemTextJson/Record.fs
+++ b/src/FSharp.SystemTextJson/Record.fs
@@ -27,7 +27,7 @@ type private RecordField
 
     let isSkippableType = isSkippableType fsOptions p.PropertyType
 
-    let canBeSkipped = ignore || ignoreNullValues options || isSkippableType
+    let canBeSkipped = ignore || (ignoreNullValues options && nullValue.IsSome) || isSkippableType
 
     let read =
         let m = p.GetGetMethod()
@@ -226,7 +226,7 @@ type JsonRecordConverter<'T> internal (options: JsonSerializerOptions, fsOptions
                 | _ -> reader.Skip()
             | _ -> ()
 
-        if requiredFieldCount < minExpectedFieldCount && not (ignoreNullValues options) then
+        if requiredFieldCount < minExpectedFieldCount then
             for i in 0 .. fieldCount - 1 do
                 if isNull fields[i] && fieldProps[i].MustBePresent then
                     failf "Missing field for record type %s: %s" recordType.FullName fieldProps[i].Names[0]

--- a/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
@@ -15,6 +15,15 @@ module NonStruct =
         Assert.Equal({ ax = 1; ay = "b" }, actual)
 
     [<Fact>]
+    let ``deserialize empty record with ignore-null-values on`` () =
+        let options = JsonSerializerOptions(DefaultIgnoreCondition = Serialization.JsonIgnoreCondition.WhenWritingNull)
+        try
+            JsonSerializer.Deserialize<A>("{}", options) |> ignore
+        with
+            | :? System.NullReferenceException -> failwith "Unexpected NRE."
+            | ex when ex.Message.Contains("Missing field for record type") -> () // It's expected to fail since the record requires its fields to be initialized.
+
+    [<Fact>]
     let ``serialize via explicit converter`` () =
         let actual = JsonSerializer.Serialize { ax = 1; ay = "b" }
         Assert.Equal("""{"ax":1,"ay":"b"}""", actual)

--- a/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
@@ -16,12 +16,13 @@ module NonStruct =
 
     [<Fact>]
     let ``deserialize empty record with ignore-null-values on`` () =
-        let options = JsonSerializerOptions(DefaultIgnoreCondition = Serialization.JsonIgnoreCondition.WhenWritingNull)
+        let options =
+            JsonSerializerOptions(DefaultIgnoreCondition = Serialization.JsonIgnoreCondition.WhenWritingNull)
         try
             JsonSerializer.Deserialize<A>("{}", options) |> ignore
         with
-            | :? System.NullReferenceException -> failwith "Unexpected NRE."
-            | ex when ex.Message.Contains("Missing field for record type") -> () // It's expected to fail since the record requires its fields to be initialized.
+        | :? System.NullReferenceException -> failwith "Unexpected NRE."
+        | ex when ex.Message.Contains("Missing field for record type") -> () // It's expected to fail since the record requires its fields to be initialized.
 
     [<Fact>]
     let ``serialize via explicit converter`` () =

--- a/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Record.fs
@@ -300,10 +300,13 @@ module NonStruct =
         Assert.Equal("""{"unignoredX":1}""", actual)
 
     let ignoreNullOptions =
-        JsonFSharpOptions().ToJsonSerializerOptions(IgnoreNullValues = true)
+        JsonFSharpOptions()
+            .WithAllowNullFields()
+            .ToJsonSerializerOptions(IgnoreNullValues = true)
 
     let newIgnoreNullOptions =
         JsonFSharpOptions()
+            .WithAllowNullFields()
             .ToJsonSerializerOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)
 
     [<AllowNullLiteral>]
@@ -763,10 +766,13 @@ module Struct =
         Assert.Equal("""{"unignoredX":1}""", actual)
 
     let ignoreNullOptions =
-        JsonFSharpOptions().ToJsonSerializerOptions(IgnoreNullValues = true)
+        JsonFSharpOptions()
+            .WithAllowNullFields()
+            .ToJsonSerializerOptions(IgnoreNullValues = true)
 
     let newIgnoreNullOptions =
         JsonFSharpOptions()
+            .WithAllowNullFields()
             .ToJsonSerializerOptions(DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)
 
     [<AllowNullLiteral>]


### PR DESCRIPTION
Fixes #164.

This MR includes the regression test from #165.

It also fixes a few tests that should have been failing, but passed thanks to this bug.

cc @mlaily