### PR TITLE
Fix NullReferenceException when serializing null record-typed record field

### DIFF
--- a/src/FSharp.SystemTextJson/Record.fs
+++ b/src/FSharp.SystemTextJson/Record.fs
@@ -205,8 +205,11 @@ type JsonRecordConverter<'T> internal (options: JsonSerializerOptions, fsOptions
         ctor fields :?> 'T
 
     override this.Write(writer, value, options) =
-        writer.WriteStartObject()
-        this.WriteRestOfObject(writer, value, options)
+        if isNull (box value) then
+            JsonSerializer.Serialize(writer, null, options)
+        else
+            writer.WriteStartObject()
+            this.WriteRestOfObject(writer, value, options)
 
     override this.HandleNull = true
 

--- a/src/FSharp.SystemTextJson/Record.fs
+++ b/src/FSharp.SystemTextJson/Record.fs
@@ -206,7 +206,7 @@ type JsonRecordConverter<'T> internal (options: JsonSerializerOptions, fsOptions
 
     override this.Write(writer, value, options) =
         if isNull (box value) then
-            JsonSerializer.Serialize(writer, null, options)
+            writer.WriteNullValue()
         else
             writer.WriteStartObject()
             this.WriteRestOfObject(writer, value, options)

--- a/tests/FSharp.SystemTextJson.Tests/Test.Regression.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Regression.fs
@@ -118,5 +118,5 @@ type X = { X: X }
 let ``regression #172`` () =
     let x = { X = Unchecked.defaultof<_> }
     let options = JsonSerializerOptions()
-    options.Converters.Add(JsonFSharpOptions.Default() |> JsonFSharpConverter)
+    options.Converters.Add(JsonFSharpConverter())
     Assert.Equal("{\"X\":null}", JsonSerializer.Serialize(x, options))

--- a/tests/FSharp.SystemTextJson.Tests/Test.Regression.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Regression.fs
@@ -119,5 +119,4 @@ let ``regression #172`` () =
     let x = { X = Unchecked.defaultof<_> }
     let options = JsonSerializerOptions()
     options.Converters.Add(JsonFSharpOptions.Default() |> JsonFSharpConverter)
-    // Should not throw
     Assert.Equal("{\"X\":null}", JsonSerializer.Serialize(x, options))

--- a/tests/FSharp.SystemTextJson.Tests/Test.Regression.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Regression.fs
@@ -120,4 +120,4 @@ let ``regression #172`` () =
     let options = JsonSerializerOptions()
     options.Converters.Add(JsonFSharpOptions.Default() |> JsonFSharpConverter)
     // Should not throw
-    JsonSerializer.Serialize(x, options) |> ignore<string>
+    Assert.Equal("{\"X\":null}", JsonSerializer.Serialize(x, options))

--- a/tests/FSharp.SystemTextJson.Tests/Test.Regression.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Regression.fs
@@ -111,3 +111,13 @@ let ``regression #154`` () =
     |> ignore
     Assert.Throws<JsonException>(fun () -> JsonSerializer.Deserialize<RV>("{}", o) |> ignore)
     |> ignore
+
+type X = { X: X }
+
+[<Fact>]
+let ``regression #172`` () =
+    let x = { X = Unchecked.defaultof<_> }
+    let options = JsonSerializerOptions()
+    options.Converters.Add(JsonFSharpOptions.Default() |> JsonFSharpConverter)
+    // Should not throw
+    JsonSerializer.Serialize(x, options) |> ignore<string>


### PR DESCRIPTION
Fixes #172 and supersedes #173.