### PR TITLE
[#151] Add option to deserialize both null and missing as None

### DIFF
--- a/src/FSharp.SystemTextJson/Helpers.fs
+++ b/src/FSharp.SystemTextJson/Helpers.fs
@@ -155,6 +155,8 @@ type FieldHelper
 
     let nullValue = tryGetNullValue fsOptions ty
     let isSkippableWrapperType = isSkippableType fsOptions ty
+    let deserializeNullAsSome =
+        isSkippableWrapperType && not fsOptions.DeserializeNullAsNone
     let ignoreNullValues =
         options.IgnoreNullValues
         || options.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
@@ -197,6 +199,7 @@ type FieldHelper
     member _.NullValue = nullValue
     member _.DefaultValue = defaultValue
     member _.IsSkippableWrapperType = isSkippableWrapperType
+    member _.DeserializeNullAsSome = deserializeNullAsSome
     member _.CanBeSkipped = canBeSkipped
     member _.IgnoreOnWrite = ignoreOnWrite
     member _.DeserializeType = deserializeType
@@ -208,7 +211,7 @@ type FieldHelper
     member this.IsNullable = this.NullValue.IsNone
 
     member this.Deserialize(reader: byref<Utf8JsonReader>) =
-        if reader.TokenType = JsonTokenType.Null && not this.IsSkippableWrapperType then
+        if reader.TokenType = JsonTokenType.Null && not this.DeserializeNullAsSome then
             match this.NullValue with
             | ValueSome v -> v
             | ValueNone -> raise (JsonException this.NullDeserializeError)

--- a/src/FSharp.SystemTextJson/Options.fs
+++ b/src/FSharp.SystemTextJson/Options.fs
@@ -181,6 +181,7 @@ type internal JsonFSharpOptionsRecord =
       AllowNullFields: bool
       IncludeRecordProperties: bool
       SkippableOptionFields: SkippableOptionFields
+      DeserializeNullAsNone: bool
       MapFormat: MapFormat
       Types: JsonFSharpTypes
       AllowOverride: bool
@@ -215,6 +216,7 @@ and JsonFSharpOptions internal (options: JsonFSharpOptionsRecord) =
               AllowNullFields = allowNullFields
               IncludeRecordProperties = includeRecordProperties
               SkippableOptionFields = SkippableOptionFields.FromJsonSerializerOptions
+              DeserializeNullAsNone = false
               MapFormat = MapFormat.ObjectOrArrayOfPairs
               Types = types
               AllowOverride = allowOverride
@@ -288,10 +290,15 @@ and JsonFSharpOptions internal (options: JsonFSharpOptionsRecord) =
     member _.WithIncludeRecordProperties([<Optional; DefaultParameterValue true>] includeRecordProperties) =
         JsonFSharpOptions({ options with IncludeRecordProperties = includeRecordProperties })
 
-    member _.WithSkippableOptionFields(skippableOptionFields) =
+    member _.WithSkippableOptionFields
+        (
+            skippableOptionFields,
+            [<Optional; DefaultParameterValue false>] deserializeNullAsNone: bool
+        ) =
         JsonFSharpOptions(
             { options with
                 SkippableOptionFields = skippableOptionFields
+                DeserializeNullAsNone = deserializeNullAsNone
                 UnionEncoding =
                     if skippableOptionFields = SkippableOptionFields.Always then
                         options.UnionEncoding ||| JsonUnionEncoding.UnwrapOption

--- a/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
@@ -1363,6 +1363,25 @@ module NonStruct =
             )
         )
 
+    [<Fact>]
+    let ``deserialize skippable option from either null or missing`` () =
+        let options =
+            JsonFSharpOptions
+                .Default()
+                .WithSkippableOptionFields(SkippableOptionFields.Always, deserializeNullAsNone = true)
+                .ToJsonSerializerOptions()
+
+        let actual = JsonSerializer.Deserialize<{| x: int option |}>("""{}""", options)
+        Assert.Equal({| x = None |}, actual)
+
+        let actual =
+            JsonSerializer.Deserialize<{| x: int option |}>("""{"x":null}""", options)
+        Assert.Equal({| x = None |}, actual)
+
+        let actual =
+            JsonSerializer.Deserialize<{| x: int option |}>("""{"x":42}""", options)
+        Assert.Equal({| x = Some 42 |}, actual)
+
 module Struct =
 
     [<Struct; JsonFSharpConverter>]
@@ -2692,3 +2711,22 @@ module Struct =
                 namedAfterTypesOptionsWithNamingPolicy
             )
         )
+
+    [<Fact>]
+    let ``deserialize skippable option from either null or missing`` () =
+        let options =
+            JsonFSharpOptions
+                .Default()
+                .WithSkippableOptionFields(SkippableOptionFields.Always, deserializeNullAsNone = true)
+                .ToJsonSerializerOptions()
+
+        let actual = JsonSerializer.Deserialize<{| x: int voption |}>("""{}""", options)
+        Assert.Equal({| x = ValueNone |}, actual)
+
+        let actual =
+            JsonSerializer.Deserialize<{| x: int voption |}>("""{"x":null}""", options)
+        Assert.Equal({| x = ValueNone |}, actual)
+
+        let actual =
+            JsonSerializer.Deserialize<{| x: int voption |}>("""{"x":42}""", options)
+        Assert.Equal({| x = ValueSome 42 |}, actual)


### PR DESCRIPTION
Add optional argument `deserializeNullAsNone: bool` to option `.WithSkippableOptionFields(SkippableOptionFields)`.

```fsharp
let options =
    JsonFSharpOptions.Default()
        .WithSkippableOptionFields(SkippableOptionFields.Always, deserializeNullAsNone = true)
        .ToJsonSerializerOptions()

JsonSerializer.Deserialize<{| x: int option|}>("""{}""", options)
// --> {| x = None |}

JsonSerializer.Deserialize<{| x: int option|}>("""{"x":null}""", options)
// --> {| x = None |}
```

Compare with the current, and now default `false` behavior:

```fsharp
let options =
    JsonFSharpOptions.Default()
        .WithSkippableOptionFields(SkippableOptionFields.Always)
        .ToJsonSerializerOptions()

JsonSerializer.Deserialize<{| x: int option|}>("""{}""", options)
// --> {| x = None |}

JsonSerializer.Deserialize<{| x: int option|}>("""{"x":null}""", options)
// JsonException: The JSON value could not be converted to System.Int32.
```

Fixes #151, #176, #182.

Note: I have changed my mind since [this comment](https://github.com/Tarmil/FSharp.SystemTextJson/issues/151#issuecomment-1427024260), in that this setting only affect `option` and `voption`, but not `Skippable`. The reason is that `Skippable` exists precisely for fields that must be skipped, and so that `Skippable<T option>` can be used to explicitly distinguish between missing and null. This ability should be usable alongside `option` values that can be deserialized from either null or missing.