### PR TITLE
Faster type comparisons

### DIFF
--- a/src/FSharp.SystemTextJson/Collection.fs
+++ b/src/FSharp.SystemTextJson/Collection.fs
@@ -197,7 +197,7 @@ type JsonMapConverter(fsOptions: JsonFSharpOptions) =
         | MapFormat.Object -> jsonMapObjectConverter genArgs options
         | MapFormat.ArrayOfPairs -> jsonMapArrayOfPairsConverter genArgs
         | MapFormat.ObjectOrArrayOfPairs ->
-            if genArgs[0] = typeof<string> || isWrappedString genArgs[0] then
+            if Type.(=)(genArgs[0], typeof<string>) || isWrappedString genArgs[0] then
                 jsonMapObjectConverter genArgs options
             else
                 jsonMapArrayOfPairsConverter genArgs

--- a/src/FSharp.SystemTextJson/Helpers.fs
+++ b/src/FSharp.SystemTextJson/Helpers.fs
@@ -92,7 +92,7 @@ let isClass ty =
 let rec tryGetNullValue (fsOptions: JsonFSharpOptionsRecord) (ty: Type) : obj voption =
     if isNullableUnion ty then
         ValueSome null
-    elif ty = typeof<unit> then
+    elif Type.(=)(ty, typeof<unit>) then
         ValueSome()
     elif fsOptions.UnionEncoding.HasFlag JsonUnionEncoding.UnwrapOption
          && isValueOptionType ty then
@@ -149,7 +149,7 @@ let isWrappedString (ty: Type) =
 
        cases.Length = 1
        && let fields = cases[ 0 ].GetFields() in
-          fields.Length = 1 && fields[0].PropertyType = typeof<string>
+          fields.Length = 1 && Type.(=)(fields[0].PropertyType, typeof<string>)
 
 type FieldHelper
     (
@@ -256,7 +256,7 @@ let getJsonFieldNames (getAttributes: Type -> obj[]) =
     |> readOnlyDict
 
 let getConverterForDictionaryKey<'T> (options: JsonSerializerOptions) =
-    if typeof<'T> = typeof<string> then
+    if Type.(=)(typeof<'T>, typeof<string>) then
         // Pre-8.0, the built-in StringConverter doesn't support {Read|Write}AsPropertyName() correctly.
         // See https://github.com/dotnet/runtime/issues/77326
         { new JsonConverter<string>() with


### PR DESCRIPTION
Faster type comparisons. More work on compile time than runtime.

See:
https://sharplab.io/#v2:DYLgZgzgNALiCGEC2AfA9gBwKYDsAEAygJ4QxZICwAUNdcFjHjEdgMJpIbwBOAlhGhwFgaAO4AKAJR4AvHnHNsaMAB4wI+DAB8spiyzK1G7ZNo1z9RoqztOPfoIBiiGFN0AVfQDpxMyQv1DdTRNLSg9JVVg0NNzMzMgA

