### PR TITLE
JsonConverter attribute support

### DIFF
--- a/src/FSharp.SystemTextJson/All.fs
+++ b/src/FSharp.SystemTextJson/All.fs
@@ -2,7 +2,6 @@ namespace System.Text.Json.Serialization
 
 open System
 open System.Collections.Generic
-open System.Reflection
 open System.Runtime.CompilerServices
 open System.Runtime.InteropServices
 open System.Text.Json

--- a/src/FSharp.SystemTextJson/All.fs
+++ b/src/FSharp.SystemTextJson/All.fs
@@ -2,6 +2,7 @@ namespace System.Text.Json.Serialization
 
 open System
 open System.Collections.Generic
+open System.Reflection
 open System.Runtime.CompilerServices
 open System.Runtime.InteropServices
 open System.Text.Json
@@ -20,6 +21,8 @@ type JsonFSharpConverter(fsOptions: JsonFSharpOptions, [<Optional>] overrides: I
     member _.Overrides = fsOptions.Overrides
 
     override _.CanConvert(typeToConvert) =
+        not (TypeCache.hasCustomJsonConverter typeToConvert)
+        &&
         match TypeCache.getKind typeToConvert with
         | TypeCache.TypeKind.List -> fsOptions.Types.HasFlag JsonFSharpTypes.Lists
         | TypeCache.TypeKind.Set -> fsOptions.Types.HasFlag JsonFSharpTypes.Sets

--- a/src/FSharp.SystemTextJson/TypeCache.fs
+++ b/src/FSharp.SystemTextJson/TypeCache.fs
@@ -1,9 +1,9 @@
 namespace System.Text.Json.Serialization
 
-open System.Reflection
 
 module TypeCache =
     open FSharp.Reflection
+    open System.Reflection
 
     // Have to use concurrentdictionary here because dictionaries thrown on non-locked access:
     (* Error Message:

--- a/src/FSharp.SystemTextJson/TypeCache.fs
+++ b/src/FSharp.SystemTextJson/TypeCache.fs
@@ -1,5 +1,7 @@
 namespace System.Text.Json.Serialization
 
+open System.Reflection
+
 module TypeCache =
     open FSharp.Reflection
 
@@ -37,6 +39,16 @@ module TypeCache =
                     elif FSharpType.IsUnion(ty, true) then TypeKind.Union
                     elif FSharpType.IsRecord(ty, true) then TypeKind.Record
                     else TypeKind.Other
+            )
+    
+    let hasCustomJsonConverter =
+        let cache = Dict<System.Type, bool>()
+        fun (ty: System.Type) ->
+            cache.GetOrAdd(
+                ty,
+                fun ty ->
+                    CustomAttributeData.GetCustomAttributes(ty)
+                    |> Seq.exists (fun cad -> cad.AttributeType = typeof<JsonConverterAttribute>)
             )
 
     let isUnion ty =

--- a/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
+++ b/tests/FSharp.SystemTextJson.Tests/Test.Union.fs
@@ -2482,6 +2482,45 @@ module Struct =
             """{"Case":"Unwrapped","Fields":["foo"]}""",
             JsonSerializer.Serialize(Unwrapped "foo", noNewtypeOptions)
         )
+        
+        
+    
+
+    [<JsonConverter(typeof<TruthConverter>)>]
+    type Truth =
+        | True
+        | False
+        | FileNotFound
+    and TruthConverter() =
+        inherit JsonConverter<Truth>()
+
+        override _.Write(writer, value, _options) =
+            writer.WriteStringValue(
+                match value with
+                | FileNotFound -> "lost"
+                | True -> "true"
+                | False -> "false"
+            )
+
+        override _.Read(reader, _typeToConvert, _options) =
+            match reader.GetString() with
+            | "lost" -> FileNotFound
+            | "true" -> True
+            | "false" -> False
+            | other -> failwithf "Unknown Truth value: %s" other
+        
+    [<Fact>]
+    let ``custom converter wins over FSharp.SystemTextJson`` () =
+        let options =
+            JsonFSharpOptions.Default().ToJsonSerializerOptions()
+
+        Assert.Equal("\"lost\"", JsonSerializer.Serialize( FileNotFound, options))
+        Assert.Equal("\"true\"", JsonSerializer.Serialize( True, options))
+        Assert.Equal("\"false\"", JsonSerializer.Serialize( False, options))
+
+        Assert.Equal(FileNotFound, JsonSerializer.Deserialize<Truth>("\"lost\"",options))
+        Assert.Equal(True, JsonSerializer.Deserialize<Truth>("\"true\"",options))
+        Assert.Equal(False, JsonSerializer.Deserialize<Truth>("\"false\"",options))
 
     module UnwrapRecord =
 


### PR DESCRIPTION
As mentioned in issue  #185 this library does not seem to respect the JsonConverterAttribute on a type. Added logic to also cache if an existing JsonConverter is defined and if so do not do any work. Added a unit test and all now pass. 